### PR TITLE
Updated sbt-auto-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # crs-fatca-registration-frontend
 
-This is a placeholder README.md for a new repository
+This service allows a user to register for the CRS/FATCA service
 
 ### Running the service
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,7 +8,7 @@ ThisBuild / libraryDependencySchemes ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % VersionScheme.Always
 )
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.20.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 

--- a/test/resources/application.conf
+++ b/test/resources/application.conf
@@ -14,8 +14,6 @@
 
 play.filters.disabled += "play.filters.csrf.CSRFFilter"
 
-play.http.secret.key = "some_secret"
-
 mongo-async-driver {
   akka {
     log-dead-letters-during-shutdown = off


### PR DESCRIPTION
Updated sbt-auto-build to latest to prevent the copyright dates being refreshed each year, plus addressed some small PR builder bot suggestions.