### PR TITLE
DAC6-2912: Add change contact details - org second contact pages

### DIFF
--- a/app/controllers/changeContactDetails/OrganisationHaveSecondContactController.scala
+++ b/app/controllers/changeContactDetails/OrganisationHaveSecondContactController.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import controllers.actions._
+import forms.changeContactDetails.OrganisationHaveSecondContactFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.changeContactDetails.OrganisationHaveSecondContactPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.auth.core.AffinityGroup
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.ContactHelper
+import views.html.changeContactDetails.OrganisationHaveSecondContactView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class OrganisationHaveSecondContactController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  standardActionSets: StandardActionSets,
+  formProvider: OrganisationHaveSecondContactFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: OrganisationHaveSecondContactView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport
+    with ContactHelper {
+
+  private val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = standardActionSets.identifiedUserWithData() {
+    implicit request =>
+      val preparedForm = request.userAnswers.get(OrganisationHaveSecondContactPage) match {
+        case None        => form
+        case Some(value) => form.fill(value)
+      }
+
+      if (request.affinityGroup == AffinityGroup.Individual) {
+        Redirect(controllers.routes.CheckYourAnswersController.onPageLoad())
+      } else {
+        Ok(view(preparedForm, getFirstContactName(request.userAnswers), mode))
+      }
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = standardActionSets.identifiedUserWithData().async {
+    implicit request =>
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, getFirstContactName(request.userAnswers), mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(OrganisationHaveSecondContactPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(OrganisationHaveSecondContactPage, mode, updatedAnswers))
+        )
+  }
+
+}

--- a/app/controllers/changeContactDetails/OrganisationSecondContactEmailController.scala
+++ b/app/controllers/changeContactDetails/OrganisationSecondContactEmailController.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import controllers.actions._
+import forms.changeContactDetails.OrganisationSecondContactEmailFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.changeContactDetails.OrganisationSecondContactEmailPage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.ContactHelper
+import views.html.changeContactDetails.OrganisationSecondContactEmailView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class OrganisationSecondContactEmailController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  standardActionSets: StandardActionSets,
+  formProvider: OrganisationSecondContactEmailFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: OrganisationSecondContactEmailView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport
+    with ContactHelper {
+
+  private val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = standardActionSets.identifiedUserWithData() {
+    implicit request =>
+      val preparedForm = request.userAnswers.get(OrganisationSecondContactEmailPage) match {
+        case None        => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode, getOrganisationSecondContactName(request.userAnswers)))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = standardActionSets.identifiedUserWithData().async {
+    implicit request =>
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, getOrganisationSecondContactName(request.userAnswers)))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(OrganisationSecondContactEmailPage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(OrganisationSecondContactEmailPage, mode, updatedAnswers))
+        )
+  }
+
+}

--- a/app/controllers/changeContactDetails/OrganisationSecondContactHavePhoneController.scala
+++ b/app/controllers/changeContactDetails/OrganisationSecondContactHavePhoneController.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import controllers.actions._
+import forms.changeContactDetails.OrganisationSecondContactHavePhoneFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.changeContactDetails.OrganisationSecondContactHavePhonePage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.ContactHelper
+import views.html.changeContactDetails.OrganisationSecondContactHavePhoneView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class OrganisationSecondContactHavePhoneController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  standardActionSets: StandardActionSets,
+  formProvider: OrganisationSecondContactHavePhoneFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: OrganisationSecondContactHavePhoneView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with ContactHelper
+    with I18nSupport {
+
+  private val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = standardActionSets.identifiedUserWithData() {
+    implicit request =>
+      val preparedForm = request.userAnswers.get(OrganisationSecondContactHavePhonePage) match {
+        case None        => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode, getOrganisationSecondContactName(request.userAnswers)))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = standardActionSets.identifiedUserWithData().async {
+    implicit request =>
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, getOrganisationSecondContactName(request.userAnswers)))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(OrganisationSecondContactHavePhonePage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(OrganisationSecondContactHavePhonePage, mode, updatedAnswers))
+        )
+  }
+
+}

--- a/app/controllers/changeContactDetails/OrganisationSecondContactNameController.scala
+++ b/app/controllers/changeContactDetails/OrganisationSecondContactNameController.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import controllers.actions._
+import forms.changeContactDetails.OrganisationSecondContactNameFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.changeContactDetails.OrganisationSecondContactNamePage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.changeContactDetails.OrganisationSecondContactNameView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class OrganisationSecondContactNameController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  standardActionSets: StandardActionSets,
+  formProvider: OrganisationSecondContactNameFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: OrganisationSecondContactNameView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with I18nSupport {
+
+  private val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = standardActionSets.identifiedUserWithData() {
+    implicit request =>
+      val preparedForm = request.userAnswers.get(OrganisationSecondContactNamePage) match {
+        case None        => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = standardActionSets.identifiedUserWithData().async {
+    implicit request =>
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(OrganisationSecondContactNamePage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(OrganisationSecondContactNamePage, mode, updatedAnswers))
+        )
+  }
+
+}

--- a/app/controllers/changeContactDetails/OrganisationSecondContactPhoneController.scala
+++ b/app/controllers/changeContactDetails/OrganisationSecondContactPhoneController.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import controllers.actions._
+import forms.changeContactDetails.OrganisationSecondContactPhoneFormProvider
+import models.Mode
+import navigation.Navigator
+import pages.changeContactDetails.OrganisationSecondContactPhonePage
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repositories.SessionRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import utils.ContactHelper
+import views.html.changeContactDetails.OrganisationSecondContactPhoneView
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class OrganisationSecondContactPhoneController @Inject() (
+  override val messagesApi: MessagesApi,
+  sessionRepository: SessionRepository,
+  navigator: Navigator,
+  standardActionSets: StandardActionSets,
+  formProvider: OrganisationSecondContactPhoneFormProvider,
+  val controllerComponents: MessagesControllerComponents,
+  view: OrganisationSecondContactPhoneView
+)(implicit ec: ExecutionContext)
+    extends FrontendBaseController
+    with ContactHelper
+    with I18nSupport {
+
+  private val form = formProvider()
+
+  def onPageLoad(mode: Mode): Action[AnyContent] = standardActionSets.identifiedUserWithData() {
+    implicit request =>
+      val preparedForm = request.userAnswers.get(OrganisationSecondContactPhonePage) match {
+        case None        => form
+        case Some(value) => form.fill(value)
+      }
+
+      Ok(view(preparedForm, mode, getOrganisationSecondContactName(request.userAnswers)))
+  }
+
+  def onSubmit(mode: Mode): Action[AnyContent] = standardActionSets.identifiedUserWithData().async {
+    implicit request =>
+      form
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, getOrganisationSecondContactName(request.userAnswers)))),
+          value =>
+            for {
+              updatedAnswers <- Future.fromTry(request.userAnswers.set(OrganisationSecondContactPhonePage, value))
+              _              <- sessionRepository.set(updatedAnswers)
+            } yield Redirect(navigator.nextPage(OrganisationSecondContactPhonePage, mode, updatedAnswers))
+        )
+  }
+
+}

--- a/app/forms/changeContactDetails/OrganisationHaveSecondContactFormProvider.scala
+++ b/app/forms/changeContactDetails/OrganisationHaveSecondContactFormProvider.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.changeContactDetails
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+import javax.inject.Inject
+
+class OrganisationHaveSecondContactFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("organisationHaveSecondContact.error.required")
+    )
+
+}

--- a/app/forms/changeContactDetails/OrganisationSecondContactEmailFormProvider.scala
+++ b/app/forms/changeContactDetails/OrganisationSecondContactEmailFormProvider.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.changeContactDetails
+
+import forms.mappings.Mappings
+import play.api.data.Form
+import utils.RegexConstants
+
+import javax.inject.Inject
+
+class OrganisationSecondContactEmailFormProvider @Inject() extends Mappings with RegexConstants {
+
+  private val maxLength = 132
+
+  def apply(): Form[String] =
+    Form(
+      "value" -> validatedText(
+        "organisationSecondContactEmail.error.required",
+        "organisationSecondContactEmail.error.invalid",
+        "organisationSecondContactEmail.error.length",
+        emailRegex,
+        maxLength
+      )
+    )
+
+}

--- a/app/forms/changeContactDetails/OrganisationSecondContactHavePhoneFormProvider.scala
+++ b/app/forms/changeContactDetails/OrganisationSecondContactHavePhoneFormProvider.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.changeContactDetails
+
+import forms.mappings.Mappings
+import play.api.data.Form
+
+import javax.inject.Inject
+
+class OrganisationSecondContactHavePhoneFormProvider @Inject() extends Mappings {
+
+  def apply(): Form[Boolean] =
+    Form(
+      "value" -> boolean("organisationSecondContactHavePhone.error.required")
+    )
+
+}

--- a/app/forms/changeContactDetails/OrganisationSecondContactNameFormProvider.scala
+++ b/app/forms/changeContactDetails/OrganisationSecondContactNameFormProvider.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.changeContactDetails
+
+import forms.mappings.Mappings
+import play.api.data.Form
+import utils.RegexConstants
+
+import javax.inject.Inject
+
+class OrganisationSecondContactNameFormProvider @Inject() extends Mappings with RegexConstants {
+
+  private val maxLength = 35
+
+  def apply(): Form[String] =
+    Form(
+      "value" -> validatedText(
+        "organisationSecondContactName.error.required",
+        "organisationSecondContactName.error.invalid",
+        "organisationSecondContactName.error.length",
+        orgNameRegex,
+        maxLength
+      )
+    )
+
+}

--- a/app/forms/changeContactDetails/OrganisationSecondContactPhoneFormProvider.scala
+++ b/app/forms/changeContactDetails/OrganisationSecondContactPhoneFormProvider.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.changeContactDetails
+
+import forms.mappings.Mappings
+import play.api.data.Form
+import utils.RegexConstants
+
+import javax.inject.Inject
+
+class OrganisationSecondContactPhoneFormProvider @Inject() extends Mappings with RegexConstants {
+
+  private val MaxLength = 24
+
+  def apply(): Form[String] =
+    Form(
+      "value" -> validatedText(
+        "organisationSecondContactPhone.error.required",
+        "organisationSecondContactPhone.error.invalid",
+        "organisationSecondContactPhone.error.length",
+        digitsAndWhiteSpaceOnly,
+        MaxLength
+      )
+    )
+
+}

--- a/app/pages/changeContactDetails/OrganisationHaveSecondContactPage.scala
+++ b/app/pages/changeContactDetails/OrganisationHaveSecondContactPage.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.changeContactDetails
+
+import models.UserAnswers
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+import scala.util.Try
+
+case object OrganisationHaveSecondContactPage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "organisationHaveSecondContact"
+
+  override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =
+    value match {
+      case Some(false) =>
+        userAnswers
+          .remove(OrganisationSecondContactNamePage)
+          .flatMap(_.remove(OrganisationSecondContactEmailPage))
+          .flatMap(_.remove(OrganisationSecondContactHavePhonePage))
+          .flatMap(_.remove(OrganisationSecondContactPhonePage))
+      case _ => super.cleanup(value, userAnswers)
+    }
+
+}

--- a/app/pages/changeContactDetails/OrganisationSecondContactEmailPage.scala
+++ b/app/pages/changeContactDetails/OrganisationSecondContactEmailPage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.changeContactDetails
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object OrganisationSecondContactEmailPage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "changeOrganisationSecondContactEmail"
+}

--- a/app/pages/changeContactDetails/OrganisationSecondContactHavePhonePage.scala
+++ b/app/pages/changeContactDetails/OrganisationSecondContactHavePhonePage.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.changeContactDetails
+
+import models.UserAnswers
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+import scala.util.Try
+
+case object OrganisationSecondContactHavePhonePage extends QuestionPage[Boolean] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "organisationSecondContactHavePhone"
+
+  override def cleanup(value: Option[Boolean], userAnswers: UserAnswers): Try[UserAnswers] =
+    value match {
+      case Some(false) => userAnswers.remove(OrganisationSecondContactPhonePage)
+      case _           => super.cleanup(value, userAnswers)
+    }
+
+}

--- a/app/pages/changeContactDetails/OrganisationSecondContactNamePage.scala
+++ b/app/pages/changeContactDetails/OrganisationSecondContactNamePage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.changeContactDetails
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object OrganisationSecondContactNamePage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "changeOrganisationSecondContactName"
+}

--- a/app/pages/changeContactDetails/OrganisationSecondContactPhonePage.scala
+++ b/app/pages/changeContactDetails/OrganisationSecondContactPhonePage.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages.changeContactDetails
+
+import pages.QuestionPage
+import play.api.libs.json.JsPath
+
+case object OrganisationSecondContactPhonePage extends QuestionPage[String] {
+
+  override def path: JsPath = JsPath \ toString
+
+  override def toString: String = "organisationSecondContactPhone"
+}

--- a/app/utils/ContactHelper.scala
+++ b/app/utils/ContactHelper.scala
@@ -17,6 +17,7 @@
 package utils
 
 import models.UserAnswers
+import pages.changeContactDetails.OrganisationSecondContactNamePage
 import pages.{ContactNamePage, SecondContactNamePage}
 import play.api.i18n.Messages
 
@@ -32,6 +33,13 @@ trait ContactHelper {
   def getSecondContactName(userAnswers: UserAnswers)(implicit messages: Messages): String =
     userAnswers
       .get(SecondContactNamePage)
+      .fold(messages("default.secondContact.name"))(
+        contactName => contactName
+      )
+
+  def getOrganisationSecondContactName(userAnswers: UserAnswers)(implicit messages: Messages): String =
+    userAnswers
+      .get(OrganisationSecondContactNamePage)
       .fold(messages("default.secondContact.name"))(
         contactName => contactName
       )

--- a/app/views/changeContactDetails/OrganisationHaveSecondContactView.scala.html
+++ b/app/views/changeContactDetails/OrganisationHaveSecondContactView.scala.html
@@ -1,0 +1,53 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import components._
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton,
+    paragraph: Paragraph,
+    heading: Heading
+)
+
+@(form: Form[_], contactName: String, mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("organisationHaveSecondContact.title"))) {
+
+    @formHelper(action = controllers.changeContactDetails.routes.OrganisationHaveSecondContactController.onSubmit(mode), 'autoComplete -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @heading(messages("organisationHaveSecondContact.heading", contactName))
+        @paragraph(Html(messages("organisationHaveSecondContact.p1")))
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field  = form("value"),
+                legend = LegendViewModel(messages("organisationHaveSecondContact.heading", contactName)).withCssClass("govuk-visually-hidden")
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/changeContactDetails/OrganisationSecondContactEmailView.scala.html
+++ b/app/views/changeContactDetails/OrganisationSecondContactEmailView.scala.html
@@ -1,0 +1,55 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.InputWidth._
+@import components._
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukInput: GovukInput,
+    govukButton: GovukButton,
+    paragraph: Paragraph,
+    heading: Heading
+)
+
+@(form: Form[_], mode: Mode, contactName: String)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("organisationSecondContactEmail.title"))) {
+
+    @formHelper(action = controllers.changeContactDetails.routes.OrganisationSecondContactEmailController.onSubmit(mode)) {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @heading(messages("organisationSecondContactEmail.heading", contactName))
+        @paragraph(Html(messages("organisationSecondContactEmail.p1")))
+
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = LabelViewModel(messages("organisationSecondContactEmail.heading")).withCssClass("govuk-visually-hidden")
+            )
+            .withWidth(Full)
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue")).withAttribute("id" -> "submit")
+        )
+    }
+}

--- a/app/views/changeContactDetails/OrganisationSecondContactHavePhoneView.scala.html
+++ b/app/views/changeContactDetails/OrganisationSecondContactHavePhoneView.scala.html
@@ -1,0 +1,53 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import components._
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukRadios: GovukRadios,
+    govukButton: GovukButton,
+    paragraph: Paragraph,
+    heading: Heading
+)
+
+@(form: Form[_], mode: Mode, secondContactName: String)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("organisationSecondContactHavePhone.title"))) {
+
+    @formHelper(action = controllers.changeContactDetails.routes.OrganisationSecondContactHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @heading(messages("organisationSecondContactHavePhone.heading", secondContactName))
+        @paragraph(Html(messages("organisationSecondContactHavePhone.p1")))
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("value"),
+                legend = LegendViewModel(messages("organisationSecondContactHavePhone.heading", secondContactName)).withCssClass("govuk-visually-hidden")
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/changeContactDetails/OrganisationSecondContactNameView.scala.html
+++ b/app/views/changeContactDetails/OrganisationSecondContactNameView.scala.html
@@ -1,0 +1,51 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.InputWidth._
+@import components._
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukInput: GovukInput,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("organisationSecondContactName.title"))) {
+
+    @formHelper(action = controllers.changeContactDetails.routes.OrganisationSecondContactNameController.onSubmit(mode)) {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = LabelViewModel(messages("organisationSecondContactName.heading")).asPageHeading()
+            )
+            .withWidth(ThreeQuarters)
+            .withHint(HintViewModel(Text(messages("organisationSecondContactName.hint"))))
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/app/views/changeContactDetails/OrganisationSecondContactPhoneView.scala.html
+++ b/app/views/changeContactDetails/OrganisationSecondContactPhoneView.scala.html
@@ -1,0 +1,50 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import viewmodels.InputWidth._
+@import components._
+
+@this(
+    layout: templates.Layout,
+    formHelper: FormWithCSRF,
+    govukErrorSummary: GovukErrorSummary,
+    govukInput: GovukInput,
+    govukButton: GovukButton
+)
+
+@(form: Form[_], mode: Mode, secondContactName: String)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = title(form, messages("organisationSecondContactPhone.title"))) {
+
+    @formHelper(action = controllers.changeContactDetails.routes.OrganisationSecondContactPhoneController.onSubmit(mode)) {
+
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+
+        @govukInput(
+            InputViewModel(
+                field = form("value"),
+                label = LabelViewModel(messages("organisationSecondContactPhone.heading", secondContactName)).asPageHeading()
+            ).withHint(HintViewModel(HtmlContent(Html(messages("organisationSecondContactPhone.hint")))))
+            .withWidth(Fixed20)
+        )
+
+        @govukButton(
+            ButtonViewModel(messages("site.continue"))
+        )
+    }
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -246,3 +246,28 @@ GET        /change-contact/individual/phone                        controllers.c
 POST       /change-contact/individual/phone                        controllers.changeContactDetails.IndividualPhoneController.onSubmit(mode: Mode = NormalMode)
 GET        /change-contact/individual/change-phone                  controllers.changeContactDetails.IndividualPhoneController.onPageLoad(mode: Mode = CheckMode)
 POST       /change-contact/individual/change-phone                  controllers.changeContactDetails.IndividualPhoneController.onSubmit(mode: Mode = CheckMode)
+
+GET         /change-contact/organisation/have-second-contact                    controllers.changeContactDetails.OrganisationHaveSecondContactController.onPageLoad(mode: Mode = NormalMode)
+POST        /change-contact/organisation/have-second-contact                    controllers.changeContactDetails.OrganisationHaveSecondContactController.onSubmit(mode: Mode = NormalMode)
+GET         /change-contact/organisation/change-have-second-contact             controllers.changeContactDetails.OrganisationHaveSecondContactController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-contact/organisation/change-have-second-contact             controllers.changeContactDetails.OrganisationHaveSecondContactController.onSubmit(mode: Mode = CheckMode)
+
+GET         /change-contact/organisation/second-contact-name                    controllers.changeContactDetails.OrganisationSecondContactNameController.onPageLoad(mode: Mode = NormalMode)
+POST        /change-contact/organisation/second-contact-name                    controllers.changeContactDetails.OrganisationSecondContactNameController.onSubmit(mode: Mode = NormalMode)
+GET         /change-contact/organisation/change-second-contact-name             controllers.changeContactDetails.OrganisationSecondContactNameController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-contact/organisation/change-second-contact-name             controllers.changeContactDetails.OrganisationSecondContactNameController.onSubmit(mode: Mode = CheckMode)
+
+GET         /change-contact/organisation/second-contact-email                   controllers.changeContactDetails.OrganisationSecondContactEmailController.onPageLoad(mode: Mode = NormalMode)
+POST        /change-contact/organisation/second-contact-email                   controllers.changeContactDetails.OrganisationSecondContactEmailController.onSubmit(mode: Mode = NormalMode)
+GET         /change-contact/organisation/change-second-contact-email            controllers.changeContactDetails.OrganisationSecondContactEmailController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-contact/organisation/change-second-contact-email            controllers.changeContactDetails.OrganisationSecondContactEmailController.onSubmit(mode: Mode = CheckMode)
+
+GET         /change-contact/organisation/second-contact-have-phone              controllers.changeContactDetails.OrganisationSecondContactHavePhoneController.onPageLoad(mode: Mode = NormalMode)
+POST        /change-contact/organisation/second-contact-have-phone              controllers.changeContactDetails.OrganisationSecondContactHavePhoneController.onSubmit(mode: Mode = NormalMode)
+GET         /change-contact/organisation/change-second-contact-have-phone       controllers.changeContactDetails.OrganisationSecondContactHavePhoneController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-contact/organisation/change-second-contact-have-phone       controllers.changeContactDetails.OrganisationSecondContactHavePhoneController.onSubmit(mode: Mode = CheckMode)
+
+GET         /change-contact/organisation/second-contact-phone                   controllers.changeContactDetails.OrganisationSecondContactPhoneController.onPageLoad(mode: Mode = NormalMode)
+POST        /change-contact/organisation/second-contact-phone                   controllers.changeContactDetails.OrganisationSecondContactPhoneController.onSubmit(mode: Mode = NormalMode)
+GET         /change-contact/organisation/change-second-contact-phone            controllers.changeContactDetails.OrganisationSecondContactPhoneController.onPageLoad(mode: Mode = CheckMode)
+POST        /change-contact/organisation/change-second-contact-phone            controllers.changeContactDetails.OrganisationSecondContactPhoneController.onSubmit(mode: Mode = CheckMode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -550,3 +550,42 @@ individualPhone.hint = For international numbers, include the country code.
 individualPhone.error.required = Enter your telephone number
 individualPhone.error.length = The telephone number must be 24 characters or less
 individualPhone.error.invalid =  The telephone number must only include numbers 0 to 9 and a plus sign, like 01632 960 001, 07700 900 982 or +44 808 157 0192
+
+organisationHaveSecondContact.title = Is there someone else we can contact if your first contact is not available?
+organisationHaveSecondContact.heading = Is there someone else we can contact if {0} is not available?
+organisationHaveSecondContact.p1 = This can be a team mailbox or another contact.
+organisationHaveSecondContact.checkYourAnswersLabel = Do you have a second contact?
+organisationHaveSecondContact.change.hidden = Change if you have a second contact
+organisationHaveSecondContact.error.required = Select yes if there is someone else we can contact
+
+organisationSecondContactEmail.title = What is the email address for the second contact?
+organisationSecondContactEmail.heading = What is the email address for {0}?
+organisationSecondContactEmail.p1 = We will use this email address to send confirmation of your reports or if we have any questions about them.
+organisationSecondContactEmail.checkYourAnswersLabel = Second contact email address
+organisationSecondContactEmail.error.required = Enter an email address for the second contact
+organisationSecondContactEmail.error.length = The email address must be 132 characters or less
+organisationSecondContactEmail.error.invalid = Enter an email address in the right format, like yourname@example.com
+organisationSecondContactEmail.change.hidden = Change second contact email address
+
+organisationSecondContactName.title = What is the name of the person or team we should contact?
+organisationSecondContactName.heading = What is the name of the person or team we should contact?
+organisationSecondContactName.hint = For example, ‘Ashley Smith’ or ‘Tax team’.
+organisationSecondContactName.checkYourAnswersLabel = Second contact name
+organisationSecondContactName.error.required = Enter a name for the second contact
+organisationSecondContactName.error.invalid = The name must only include letters a to z, numbers 0 to 9, ampersands (&), apostrophes, backslashes, carets (^), grave accents (`), hyphens and spaces
+organisationSecondContactName.error.length = The name must be 35 characters or less
+organisationSecondContactName.change.hidden = Change second contact name
+
+organisationSecondContactHavePhone.title = Can we contact your second contact by telephone?
+organisationSecondContactHavePhone.heading = Can we contact {0} by telephone?
+organisationSecondContactHavePhone.p1 = We will call if we have any questions about your reports.
+organisationSecondContactHavePhone.error.required = Select yes if they can be contacted by telephone
+
+organisationSecondContactPhone.title = What is the telephone number for the second contact?
+organisationSecondContactPhone.heading = What is the telephone number for {0}?
+organisationSecondContactPhone.hint = For international numbers, include the country code.
+organisationSecondContactPhone.checkYourAnswersLabel = Second contact telephone number
+organisationSecondContactPhone.error.required = Enter a telephone number for the second contact
+organisationSecondContactPhone.error.invalid = The telephone number must only include numbers 0 to 9 and a plus sign, like 01632 960 001, 07700 900 982 or +44 808 157 0192
+organisationSecondContactPhone.error.length = The telephone number must be 24 characters or less
+organisationSecondContactPhone.change.hidden = Change second contact telephone number

--- a/test/controllers/changeContactDetails/OrganisationHaveSecondContactControllerSpec.scala
+++ b/test/controllers/changeContactDetails/OrganisationHaveSecondContactControllerSpec.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import base.{SpecBase, TestValues}
+import forms.changeContactDetails.OrganisationHaveSecondContactFormProvider
+import models.NormalMode
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatestplus.mockito.MockitoSugar
+import pages.ContactNamePage
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import uk.gov.hmrc.auth.core.AffinityGroup
+import views.html.changeContactDetails.OrganisationHaveSecondContactView
+
+import scala.concurrent.Future
+
+class OrganisationHaveSecondContactControllerSpec extends SpecBase with MockitoSugar with TableDrivenPropertyChecks with TestValues {
+
+  private lazy val haveSecondContactRoute = routes.OrganisationHaveSecondContactController.onPageLoad(NormalMode).url
+
+  val formProvider = new OrganisationHaveSecondContactFormProvider()
+  private val form = formProvider()
+
+  "Change Organisation HaveSecondContact Controller" - {
+
+    forAll(Table("nonIndividualAffinityGroup", Seq(AffinityGroup.Organisation, AffinityGroup.Agent): _*)) {
+      affinityGroup =>
+        s"must return OK and the correct view for a GET when affinity group is $affinityGroup" in {
+
+          val userAnswers = emptyUserAnswers.withPage(ContactNamePage, name.fullName)
+          val application = applicationBuilder(userAnswers = Some(userAnswers), affinityGroup).build()
+
+          running(application) {
+            val request = FakeRequest(GET, haveSecondContactRoute)
+
+            val result = route(application, request).value
+
+            val view = application.injector.instanceOf[OrganisationHaveSecondContactView]
+
+            status(result) mustEqual OK
+            contentAsString(result) mustEqual view(form, name.fullName, NormalMode)(request, messages(application)).toString
+          }
+        }
+    }
+
+    "must redirect to CheckYourAnswersPage for a GET when affinity group is Individual" in {
+
+      val userAnswers = emptyUserAnswers
+      val application = applicationBuilder(userAnswers = Some(userAnswers), AffinityGroup.Individual).build()
+
+      running(application) {
+        val request = FakeRequest(GET, haveSecondContactRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.CheckYourAnswersController.onPageLoad().url
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute))
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, haveSecondContactRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers.withPage(ContactNamePage, name.fullName))).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, haveSecondContactRoute)
+            .withFormUrlEncodedBody(("value", "invalid value"))
+
+        val boundForm = form.bind(Map("value" -> "invalid value"))
+
+        val view = application.injector.instanceOf[OrganisationHaveSecondContactView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, name.fullName, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, haveSecondContactRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, haveSecondContactRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+
+}

--- a/test/controllers/changeContactDetails/OrganisationSecondContactEmailControllerSpec.scala
+++ b/test/controllers/changeContactDetails/OrganisationSecondContactEmailControllerSpec.scala
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import base.{SpecBase, TestValues}
+import forms.SecondContactEmailFormProvider
+import models.{NormalMode, UserAnswers}
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.changeContactDetails.{OrganisationSecondContactEmailPage, OrganisationSecondContactNamePage}
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.changeContactDetails.OrganisationSecondContactEmailView
+
+import scala.concurrent.Future
+
+class OrganisationSecondContactEmailControllerSpec extends SpecBase with MockitoSugar with TestValues {
+
+  val formProvider = new SecondContactEmailFormProvider()
+  private val form = formProvider()
+
+  private lazy val secondContactEmailRoute = routes.OrganisationSecondContactEmailController.onPageLoad(NormalMode).url
+
+  "Change Organisation SecondContactEmail Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val userAnswers = UserAnswers(userAnswersId)
+        .set(OrganisationSecondContactNamePage, name.fullName)
+        .success
+        .value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, secondContactEmailRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[OrganisationSecondContactEmailView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode, name.fullName)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = UserAnswers(userAnswersId)
+        .set(OrganisationSecondContactNamePage, name.fullName)
+        .success
+        .value
+        .set(OrganisationSecondContactEmailPage, "answer")
+        .success
+        .value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, secondContactEmailRoute)
+
+        val view = application.injector.instanceOf[OrganisationSecondContactEmailView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode, name.fullName)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute))
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, secondContactEmailRoute)
+            .withFormUrlEncodedBody(("value", "test@test.com"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val userAnswers = UserAnswers(userAnswersId)
+        .set(OrganisationSecondContactNamePage, name.fullName)
+        .success
+        .value
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, secondContactEmailRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[OrganisationSecondContactEmailView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode, name.fullName)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, secondContactEmailRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, secondContactEmailRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+
+}

--- a/test/controllers/changeContactDetails/OrganisationSecondContactHavePhoneControllerSpec.scala
+++ b/test/controllers/changeContactDetails/OrganisationSecondContactHavePhoneControllerSpec.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import base.{SpecBase, TestValues}
+import forms.changeContactDetails.OrganisationSecondContactHavePhoneFormProvider
+import models.NormalMode
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.changeContactDetails.{OrganisationSecondContactHavePhonePage, OrganisationSecondContactNamePage}
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.changeContactDetails.OrganisationSecondContactHavePhoneView
+
+import scala.concurrent.Future
+
+class OrganisationSecondContactHavePhoneControllerSpec extends SpecBase with MockitoSugar with TestValues {
+
+  val formProvider = new OrganisationSecondContactHavePhoneFormProvider()
+  private val form = formProvider()
+
+  private lazy val secondContactHavePhoneRoute = routes.OrganisationSecondContactHavePhoneController.onPageLoad(NormalMode).url
+
+  "Change Organisation SecondContactHavePhone Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers.withPage(OrganisationSecondContactNamePage, name.fullName)))
+        .build()
+
+      running(application) {
+        val request = FakeRequest(GET, secondContactHavePhoneRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[OrganisationSecondContactHavePhoneView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode, name.fullName)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = emptyUserAnswers
+        .withPage(OrganisationSecondContactHavePhonePage, true)
+        .withPage(OrganisationSecondContactNamePage, name.fullName)
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, secondContactHavePhoneRoute)
+
+        val view = application.injector.instanceOf[OrganisationSecondContactHavePhoneView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(true), NormalMode, name.fullName)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers.withPage(OrganisationSecondContactNamePage, name.fullName)))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute))
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, secondContactHavePhoneRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers.withPage(OrganisationSecondContactNamePage, name.fullName)))
+        .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, secondContactHavePhoneRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[OrganisationSecondContactHavePhoneView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode, name.fullName)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, secondContactHavePhoneRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, secondContactHavePhoneRoute)
+            .withFormUrlEncodedBody(("value", "true"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+
+}

--- a/test/controllers/changeContactDetails/OrganisationSecondContactNameControllerSpec.scala
+++ b/test/controllers/changeContactDetails/OrganisationSecondContactNameControllerSpec.scala
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import base.SpecBase
+import forms.changeContactDetails.OrganisationSecondContactNameFormProvider
+import models.NormalMode
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.changeContactDetails.OrganisationSecondContactNamePage
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.changeContactDetails.OrganisationSecondContactNameView
+
+import scala.concurrent.Future
+
+class OrganisationSecondContactNameControllerSpec extends SpecBase with MockitoSugar {
+
+  val formProvider = new OrganisationSecondContactNameFormProvider()
+  private val form = formProvider()
+
+  private lazy val secondContactNameRoute = routes.OrganisationSecondContactNameController.onPageLoad(NormalMode).url
+
+  "Change Organisation SecondContactName Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, secondContactNameRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[OrganisationSecondContactNameView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = emptyUserAnswers.withPage(OrganisationSecondContactNamePage, "answer")
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, secondContactNameRoute)
+
+        val view = application.injector.instanceOf[OrganisationSecondContactNameView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill("answer"), NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute))
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, secondContactNameRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, secondContactNameRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[OrganisationSecondContactNameView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, secondContactNameRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, secondContactNameRoute)
+            .withFormUrlEncodedBody(("value", "answer"))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+
+}

--- a/test/controllers/changeContactDetails/OrganisationSecondContactPhoneControllerSpec.scala
+++ b/test/controllers/changeContactDetails/OrganisationSecondContactPhoneControllerSpec.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.changeContactDetails
+
+import base.{SpecBase, TestValues}
+import forms.changeContactDetails.OrganisationSecondContactPhoneFormProvider
+import models.NormalMode
+import navigation.{FakeNavigator, Navigator}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
+import org.scalatestplus.mockito.MockitoSugar
+import pages.changeContactDetails.{OrganisationSecondContactNamePage, OrganisationSecondContactPhonePage}
+import play.api.inject.bind
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.changeContactDetails.OrganisationSecondContactPhoneView
+
+import scala.concurrent.Future
+
+class OrganisationSecondContactPhoneControllerSpec extends SpecBase with MockitoSugar with TestValues {
+
+  val formProvider = new OrganisationSecondContactPhoneFormProvider()
+  private val form = formProvider()
+
+  private lazy val secondContactPhoneRoute = routes.OrganisationSecondContactPhoneController.onPageLoad(NormalMode).url
+
+  "Change Organisation SecondContactPhone Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val userAnswers = emptyUserAnswers.withPage(OrganisationSecondContactNamePage, name.fullName)
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, secondContactPhoneRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[OrganisationSecondContactPhoneView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form, NormalMode, name.fullName)(request, messages(application)).toString
+      }
+    }
+
+    "must populate the view correctly on a GET when the question has previously been answered" in {
+
+      val userAnswers = emptyUserAnswers
+        .withPage(OrganisationSecondContactNamePage, name.fullName)
+        .withPage(OrganisationSecondContactPhonePage, TestPhoneNumber)
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, secondContactPhoneRoute)
+
+        val view = application.injector.instanceOf[OrganisationSecondContactPhoneView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(form.fill(TestPhoneNumber), NormalMode, name.fullName)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to the next page when valid data is submitted" in {
+
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+
+      val application =
+        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+          .overrides(
+            bind[Navigator].toInstance(new FakeNavigator(onwardRoute))
+          )
+          .build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, secondContactPhoneRoute)
+            .withFormUrlEncodedBody(("value", TestPhoneNumber))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual onwardRoute.url
+      }
+    }
+
+    "must return a Bad Request and errors when invalid data is submitted" in {
+
+      val userAnswers = emptyUserAnswers.withPage(OrganisationSecondContactNamePage, name.fullName)
+      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, secondContactPhoneRoute)
+            .withFormUrlEncodedBody(("value", ""))
+
+        val boundForm = form.bind(Map("value" -> ""))
+
+        val view = application.injector.instanceOf[OrganisationSecondContactPhoneView]
+
+        val result = route(application, request).value
+
+        status(result) mustEqual BAD_REQUEST
+        contentAsString(result) mustEqual view(boundForm, NormalMode, name.fullName)(request, messages(application)).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, secondContactPhoneRoute)
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+
+    "must redirect to Journey Recovery for a POST if no existing data is found" in {
+
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request =
+          FakeRequest(POST, secondContactPhoneRoute)
+            .withFormUrlEncodedBody(("value", TestPhoneNumber))
+
+        val result = route(application, request).value
+
+        status(result) mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+
+}

--- a/test/forms/changeContactDetails/OrganisationHaveSecondContactFormProviderSpec.scala
+++ b/test/forms/changeContactDetails/OrganisationHaveSecondContactFormProviderSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.changeContactDetails
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class OrganisationHaveSecondContactFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "organisationHaveSecondContact.error.required"
+  val invalidKey  = "error.boolean"
+
+  val form = new OrganisationHaveSecondContactFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+
+}

--- a/test/forms/changeContactDetails/OrganisationSecondContactEmailFormProviderSpec.scala
+++ b/test/forms/changeContactDetails/OrganisationSecondContactEmailFormProviderSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.changeContactDetails
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+import utils.RegexConstants
+
+class OrganisationSecondContactEmailFormProviderSpec extends StringFieldBehaviours with RegexConstants {
+
+  val requiredKey = "organisationSecondContactEmail.error.required"
+  val invalidKey  = "organisationSecondContactEmail.error.invalid"
+  val lengthKey   = "organisationSecondContactEmail.error.length"
+  val maxLength   = 132
+
+  val form = new OrganisationSecondContactEmailFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      emailMatchingRegexAndLength(emailRegex, maxLength)
+    )
+
+    behave like fieldWithInvalidData(
+      form,
+      fieldName,
+      invalidString = "not a valid email",
+      error = FormError(fieldName, invalidKey)
+    )
+
+    behave like fieldWithMaxLengthEmail(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+
+}

--- a/test/forms/changeContactDetails/OrganisationSecondContactHavePhoneFormProviderSpec.scala
+++ b/test/forms/changeContactDetails/OrganisationSecondContactHavePhoneFormProviderSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.changeContactDetails
+
+import forms.behaviours.BooleanFieldBehaviours
+import play.api.data.FormError
+
+class OrganisationSecondContactHavePhoneFormProviderSpec extends BooleanFieldBehaviours {
+
+  val requiredKey = "organisationSecondContactHavePhone.error.required"
+  val invalidKey  = "error.boolean"
+
+  val form = new OrganisationSecondContactHavePhoneFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like booleanField(
+      form,
+      fieldName,
+      invalidError = FormError(fieldName, invalidKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+  }
+
+}

--- a/test/forms/changeContactDetails/OrganisationSecondContactNameFormProviderSpec.scala
+++ b/test/forms/changeContactDetails/OrganisationSecondContactNameFormProviderSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.changeContactDetails
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+import utils.RegexConstants
+
+class OrganisationSecondContactNameFormProviderSpec extends StringFieldBehaviours with RegexConstants {
+
+  val requiredKey = "organisationSecondContactName.error.required"
+  val invalidKey  = "organisationSecondContactName.error.invalid"
+  val lengthKey   = "organisationSecondContactName.error.length"
+  val maxLength   = 35
+
+  val form = new OrganisationSecondContactNameFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      stringMatchingRegexAndLength(orgNameRegex, maxLength)
+    )
+
+    behave like fieldWithMaxLengthAlpha(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey)
+    )
+
+    behave like fieldWithNonEmptyWhitespace(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithInvalidData(
+      form,
+      fieldName,
+      "jjdjdj£%^&kfkf",
+      FormError(fieldName, invalidKey)
+    )
+  }
+
+}

--- a/test/forms/changeContactDetails/OrganisationSecondContactPhoneFormProviderSpec.scala
+++ b/test/forms/changeContactDetails/OrganisationSecondContactPhoneFormProviderSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.changeContactDetails
+
+import forms.behaviours.StringFieldBehaviours
+import play.api.data.FormError
+
+class OrganisationSecondContactPhoneFormProviderSpec extends StringFieldBehaviours {
+
+  val requiredKey = "organisationSecondContactPhone.error.required"
+  val lengthKey   = "organisationSecondContactPhone.error.length"
+  val invalidKey  = "organisationSecondContactPhone.error.invalid"
+  val maxLength   = 24
+
+  val form = new OrganisationSecondContactPhoneFormProvider()()
+
+  ".value" - {
+
+    val fieldName = "value"
+
+    behave like fieldThatBindsValidData(
+      form,
+      fieldName,
+      validPhoneNumber(maxLength)
+    )
+
+    behave like numericFieldWithMaxLength(
+      form,
+      fieldName,
+      maxLength = maxLength,
+      lengthError = FormError(fieldName, lengthKey)
+    )
+
+    behave like mandatoryField(
+      form,
+      fieldName,
+      requiredError = FormError(fieldName, requiredKey)
+    )
+
+    behave like fieldWithInvalidData(
+      form,
+      fieldName,
+      "jjdjdj£%^&kfkf",
+      FormError(fieldName, invalidKey)
+    )
+  }
+
+}


### PR DESCRIPTION
This PR:
- Adds the change contact details - org second contact pages
- The ticket excludes navigation