### PR TITLE
DAC6-3018: Fix change address

### DIFF
--- a/app/pages/IndNonUKAddressWithoutIdPage.scala
+++ b/app/pages/IndNonUKAddressWithoutIdPage.scala
@@ -23,5 +23,5 @@ case object IndNonUKAddressWithoutIdPage extends QuestionPage[Address] {
 
   override def path: JsPath = JsPath \ toString
 
-  override def toString: String = "addressWithoutId"
+  override def toString: String = "nonUkAddressWithoutId"
 }

--- a/app/pages/IndUKAddressWithoutIdPage.scala
+++ b/app/pages/IndUKAddressWithoutIdPage.scala
@@ -16,20 +16,13 @@
 
 package pages
 
-import models.{Address, UserAnswers}
+import models.Address
 import play.api.libs.json.JsPath
-
-import scala.util.Try
 
 case object IndUKAddressWithoutIdPage extends QuestionPage[Address] {
 
   override def path: JsPath = JsPath \ toString
 
   override def toString: String = "addressWithoutId"
-
-  override def cleanup(value: Option[Address], userAnswers: UserAnswers): Try[UserAnswers] =
-    value.fold(Try(userAnswers))(
-      _ => userAnswers.remove(IndSelectAddressPage)
-    )
 
 }

--- a/app/pages/IndUKAddressWithoutIdPage.scala
+++ b/app/pages/IndUKAddressWithoutIdPage.scala
@@ -16,13 +16,20 @@
 
 package pages
 
-import models.Address
+import models.{Address, UserAnswers}
 import play.api.libs.json.JsPath
+
+import scala.util.Try
 
 case object IndUKAddressWithoutIdPage extends QuestionPage[Address] {
 
   override def path: JsPath = JsPath \ toString
 
-  override def toString: String = "addressWithoutId"
+  override def toString: String = "ukAddressWithoutId"
+
+  override def cleanup(value: Option[Address], userAnswers: UserAnswers): Try[UserAnswers] =
+    value.fold(Try(userAnswers))(
+      _ => userAnswers.remove(IndSelectAddressPage)
+    )
 
 }

--- a/app/pages/IndWhereDoYouLivePage.scala
+++ b/app/pages/IndWhereDoYouLivePage.scala
@@ -38,7 +38,6 @@ case object IndWhereDoYouLivePage extends QuestionPage[Boolean] {
       List(
         IndWhatIsYourPostcodePage,
         IndSelectAddressPage,
-        IndNonUKAddressWithoutIdPage,
         IndSelectedAddressLookupPage,
         AddressLookupPage
       ).foldLeft(Try(userAnswers))(PageLists.removePage)

--- a/app/pages/IndWhereDoYouLivePage.scala
+++ b/app/pages/IndWhereDoYouLivePage.scala
@@ -31,7 +31,7 @@ case object IndWhereDoYouLivePage extends QuestionPage[Boolean] {
 
     case Some(true) =>
       List(
-        IndUKAddressWithoutIdPage
+        IndSelectAddressPage
       ).foldLeft(Try(userAnswers))(PageLists.removePage)
 
     case Some(false) =>

--- a/app/pages/IndWhereDoYouLivePage.scala
+++ b/app/pages/IndWhereDoYouLivePage.scala
@@ -31,13 +31,14 @@ case object IndWhereDoYouLivePage extends QuestionPage[Boolean] {
 
     case Some(true) =>
       List(
-        IndSelectAddressPage
+        IndNonUKAddressWithoutIdPage
       ).foldLeft(Try(userAnswers))(PageLists.removePage)
 
     case Some(false) =>
       List(
         IndWhatIsYourPostcodePage,
         IndSelectAddressPage,
+        IndUKAddressWithoutIdPage,
         IndSelectedAddressLookupPage,
         AddressLookupPage
       ).foldLeft(Try(userAnswers))(PageLists.removePage)

--- a/test/pages/IndUKAddressWithoutIdPageSpec.scala
+++ b/test/pages/IndUKAddressWithoutIdPageSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import models.Address
+import org.scalacheck.Arbitrary.arbitrary
+import pages.behaviours.PageBehaviours
+
+class IndUKAddressWithoutIdPageSpec extends PageBehaviours {
+
+  "IndUKAddressWithoutIdPage" - {
+
+    beRetrievable[Address](IndUKAddressWithoutIdPage)
+
+    beSettable[Address](IndUKAddressWithoutIdPage)
+
+    beRemovable[Address](IndUKAddressWithoutIdPage)
+
+    "cleanup" - {
+      "must remove IndSelectAddressPage" - {
+        val generator = for {
+          addressLookup <- arbitrary[models.AddressLookup]
+          address       <- arbitrary[models.Address]
+        } yield (addressLookup, address)
+
+        forAll(generator) {
+          case (addressLookup, address) =>
+            val userAnswers = emptyUserAnswers.withPage(IndSelectAddressPage, addressLookup.format)
+
+            val result = IndUKAddressWithoutIdPage.cleanup(Option(address), userAnswers).success.value
+
+            result.get(IndSelectAddressPage) mustBe empty
+        }
+      }
+    }
+  }
+
+}

--- a/test/pages/IndWhereDoYouLivePageSpec.scala
+++ b/test/pages/IndWhereDoYouLivePageSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pages
+
+import helpers.JsonFixtures.TestPostCode
+import org.scalacheck.Arbitrary.arbitrary
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import pages.behaviours.PageBehaviours
+
+class IndWhereDoYouLivePageSpec extends PageBehaviours {
+
+  "IndWhereDoYouLivePage" - {
+
+    beRetrievable[Boolean](IndWhereDoYouLivePage)
+
+    beSettable[Boolean](IndWhereDoYouLivePage)
+
+    beRemovable[Boolean](IndWhereDoYouLivePage)
+
+    "cleanup" - {
+      "must only remove IndUKAddressWithoutIdPage answer when true" - {
+        ScalaCheckPropertyChecks.forAll(arbitrary[models.AddressLookup]) {
+          addressLookup =>
+            ScalaCheckPropertyChecks.forAll(arbitrary[models.Address]) {
+              address =>
+                val userAnswers = emptyUserAnswers
+                  .withPage(IndUKAddressWithoutIdPage, address)
+                  .withPage(IndWhatIsYourPostcodePage, TestPostCode)
+                  .withPage(IndSelectAddressPage, addressLookup.format)
+                  .withPage(IndSelectedAddressLookupPage, addressLookup)
+                  .withPage(AddressLookupPage, Seq(addressLookup))
+
+                val result = IndWhereDoYouLivePage.cleanup(Some(true), userAnswers).success.value
+
+                result.get(IndUKAddressWithoutIdPage) mustBe empty
+                result.get(IndWhatIsYourPostcodePage) must not be empty
+                result.get(IndSelectAddressPage) must not be empty
+                result.get(IndSelectedAddressLookupPage) must not be empty
+                result.get(AddressLookupPage) must not be empty
+            }
+        }
+      }
+
+      "must only remove IndWhatIsYourPostcodePage, IndSelectAddressPage, IndSelectedAddressLookupPage, and AddressLookupPage answers when false" - {
+        ScalaCheckPropertyChecks.forAll(arbitrary[models.AddressLookup]) {
+          addressLookup =>
+            ScalaCheckPropertyChecks.forAll(arbitrary[models.Address]) {
+              address =>
+                val userAnswers = emptyUserAnswers
+                  .withPage(IndWhatIsYourPostcodePage, TestPostCode)
+                  .withPage(IndSelectAddressPage, addressLookup.format)
+                  .withPage(IndSelectedAddressLookupPage, addressLookup)
+                  .withPage(AddressLookupPage, Seq(addressLookup))
+                  .withPage(IndUKAddressWithoutIdPage, address)
+
+                val result = IndWhereDoYouLivePage.cleanup(Some(false), userAnswers).success.value
+
+                result.get(IndWhatIsYourPostcodePage) mustBe empty
+                result.get(IndSelectAddressPage) mustBe empty
+                result.get(IndSelectedAddressLookupPage) mustBe empty
+                result.get(AddressLookupPage) mustBe empty
+                result.get(IndUKAddressWithoutIdPage) must not be empty
+            }
+        }
+      }
+    }
+  }
+
+}

--- a/test/pages/IndWhereDoYouLivePageSpec.scala
+++ b/test/pages/IndWhereDoYouLivePageSpec.scala
@@ -32,25 +32,26 @@ class IndWhereDoYouLivePageSpec extends PageBehaviours {
     beRemovable[Boolean](IndWhereDoYouLivePage)
 
     "cleanup" - {
-      "must only remove IndUKAddressWithoutIdPage answer when true" - {
+      "must only remove IndSelectAddressPage answers when true" - {
         ScalaCheckPropertyChecks.forAll(arbitrary[models.AddressLookup]) {
           addressLookup =>
             ScalaCheckPropertyChecks.forAll(arbitrary[models.Address]) {
               address =>
                 val userAnswers = emptyUserAnswers
-                  .withPage(IndUKAddressWithoutIdPage, address)
-                  .withPage(IndWhatIsYourPostcodePage, TestPostCode)
                   .withPage(IndSelectAddressPage, addressLookup.format)
+                  .withPage(IndWhatIsYourPostcodePage, TestPostCode)
                   .withPage(IndSelectedAddressLookupPage, addressLookup)
                   .withPage(AddressLookupPage, Seq(addressLookup))
+                  .withPage(IndUKAddressWithoutIdPage, address)
 
                 val result = IndWhereDoYouLivePage.cleanup(Some(true), userAnswers).success.value
 
-                result.get(IndUKAddressWithoutIdPage) mustBe empty
+                result.get(IndSelectAddressPage) mustBe empty
+
                 result.get(IndWhatIsYourPostcodePage) must not be empty
-                result.get(IndSelectAddressPage) must not be empty
                 result.get(IndSelectedAddressLookupPage) must not be empty
                 result.get(AddressLookupPage) must not be empty
+                result.get(IndUKAddressWithoutIdPage) must not be empty
             }
         }
       }
@@ -73,6 +74,7 @@ class IndWhereDoYouLivePageSpec extends PageBehaviours {
                 result.get(IndSelectAddressPage) mustBe empty
                 result.get(IndSelectedAddressLookupPage) mustBe empty
                 result.get(AddressLookupPage) mustBe empty
+
                 result.get(IndUKAddressWithoutIdPage) must not be empty
             }
         }

--- a/test/pages/IndWhereDoYouLivePageSpec.scala
+++ b/test/pages/IndWhereDoYouLivePageSpec.scala
@@ -32,53 +32,42 @@ class IndWhereDoYouLivePageSpec extends PageBehaviours {
     beRemovable[Boolean](IndWhereDoYouLivePage)
 
     "cleanup" - {
-      "must only remove IndSelectAddressPage answers when true" - {
-        ScalaCheckPropertyChecks.forAll(arbitrary[models.AddressLookup]) {
-          addressLookup =>
-            ScalaCheckPropertyChecks.forAll(arbitrary[models.Address]) {
-              address =>
-                val userAnswers = emptyUserAnswers
-                  .withPage(IndSelectAddressPage, addressLookup.format)
-                  .withPage(IndWhatIsYourPostcodePage, TestPostCode)
-                  .withPage(IndSelectedAddressLookupPage, addressLookup)
-                  .withPage(AddressLookupPage, Seq(addressLookup))
-                  .withPage(IndUKAddressWithoutIdPage, address)
+      "must remove IndNonUKAddressWithoutIdPage answers when true" - {
+        ScalaCheckPropertyChecks.forAll(arbitrary[models.Address]) {
+          address =>
+            val userAnswers = emptyUserAnswers.withPage(IndNonUKAddressWithoutIdPage, address)
 
-                val result = IndWhereDoYouLivePage.cleanup(Some(true), userAnswers).success.value
+            val result = IndWhereDoYouLivePage.cleanup(Some(true), userAnswers).success.value
 
-                result.get(IndSelectAddressPage) mustBe empty
-
-                result.get(IndWhatIsYourPostcodePage) must not be empty
-                result.get(IndSelectedAddressLookupPage) must not be empty
-                result.get(AddressLookupPage) must not be empty
-                result.get(IndUKAddressWithoutIdPage) must not be empty
-            }
+            result.get(IndNonUKAddressWithoutIdPage) mustBe empty
         }
       }
 
-      "must only remove IndWhatIsYourPostcodePage, IndSelectAddressPage, IndSelectedAddressLookupPage, and AddressLookupPage answers when false" - {
-        ScalaCheckPropertyChecks.forAll(arbitrary[models.AddressLookup]) {
-          addressLookup =>
-            ScalaCheckPropertyChecks.forAll(arbitrary[models.Address]) {
-              address =>
-                val userAnswers = emptyUserAnswers
-                  .withPage(IndWhatIsYourPostcodePage, TestPostCode)
-                  .withPage(IndSelectAddressPage, addressLookup.format)
-                  .withPage(IndSelectedAddressLookupPage, addressLookup)
-                  .withPage(AddressLookupPage, Seq(addressLookup))
-                  .withPage(IndUKAddressWithoutIdPage, address)
+      "must remove IndWhatIsYourPostcodePage, IndSelectAddressPage, IndUKAddressWithoutIdPage, IndSelectedAddressLookupPage, " +
+        "and AddressLookupPage answers when false" - {
+          val generator = for {
+            addressLookup <- arbitrary[models.AddressLookup]
+            address       <- arbitrary[models.Address]
+          } yield (addressLookup, address)
 
-                val result = IndWhereDoYouLivePage.cleanup(Some(false), userAnswers).success.value
+          forAll(generator) {
+            case (addressLookup, address) =>
+              val userAnswers = emptyUserAnswers
+                .withPage(IndSelectAddressPage, addressLookup.format)
+                .withPage(IndWhatIsYourPostcodePage, TestPostCode)
+                .withPage(IndSelectedAddressLookupPage, addressLookup)
+                .withPage(AddressLookupPage, Seq(addressLookup))
+                .withPage(IndUKAddressWithoutIdPage, address)
 
-                result.get(IndWhatIsYourPostcodePage) mustBe empty
-                result.get(IndSelectAddressPage) mustBe empty
-                result.get(IndSelectedAddressLookupPage) mustBe empty
-                result.get(AddressLookupPage) mustBe empty
+              val result = IndWhereDoYouLivePage.cleanup(Some(false), userAnswers).success.value
 
-                result.get(IndUKAddressWithoutIdPage) must not be empty
-            }
+              result.get(IndSelectAddressPage) mustBe empty
+              result.get(IndWhatIsYourPostcodePage) mustBe empty
+              result.get(IndSelectedAddressLookupPage) mustBe empty
+              result.get(AddressLookupPage) mustBe empty
+              result.get(IndUKAddressWithoutIdPage) mustBe empty
+          }
         }
-      }
     }
   }
 


### PR DESCRIPTION
This PR fixes the QA issue raised where if a user goes to the change address page the previously entered values are cleared from the text boxes because `IndNonUKAddressWithoutIdPage` is cleared.