### PR TITLE
DAC6-3156: Updated individual "could not confirm identity" page logic

### DIFF
--- a/app/controllers/individual/IndCouldNotConfirmIdentityController.scala
+++ b/app/controllers/individual/IndCouldNotConfirmIdentityController.scala
@@ -17,50 +17,28 @@
 package controllers.individual
 
 import controllers.actions._
-import models.requests.DataRequest
-import pages.PageLists
 import play.api.Logging
 
 import javax.inject.Inject
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import repositories.SessionRepository
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.individual.IndCouldNotConfirmIdentityView
-
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Success, Try}
 
 class IndCouldNotConfirmIdentityController @Inject() (
   override val messagesApi: MessagesApi,
   standardActionSets: StandardActionSets,
-  sessionRepository: SessionRepository,
   val controllerComponents: MessagesControllerComponents,
   view: IndCouldNotConfirmIdentityView
-)(implicit ec: ExecutionContext)
-    extends FrontendBaseController
+) extends FrontendBaseController
     with I18nSupport
     with Logging {
 
-  def onPageLoad(key: String): Action[AnyContent] =
-    standardActionSets.identifiedUserWithData().async {
-      implicit request =>
-        val continueUrl = controllers.routes.IndexController.onPageLoad.url
+  def onPageLoad(key: String): Action[AnyContent] = standardActionSets.identifiedUserWithData() {
+    implicit request =>
+      val continueUrl = controllers.routes.IndexController.onPageLoad.url
 
-        cleanPages match {
-          case Success(cleaned) =>
-            cleaned map (
-              _ => Ok(view(continueUrl, key))
-            )
-          case _ =>
-            logger.warn("WeCouldNotConfirmController: Could not clean pages")
-            throw new Exception("WeCouldNotConfirmController: Cannot clean UserAnswers pages")
-        }
-
-    }
-
-  private def cleanPages(implicit request: DataRequest[AnyContent]): Try[Future[Boolean]] = for {
-    cleaned <- (PageLists.individualWithIDPages ++ PageLists.businessWithIdPages).foldLeft(Try(request.userAnswers))(PageLists.removePage)
-  } yield sessionRepository.set(cleaned)
+      Ok(view(continueUrl, key))
+  }
 
 }

--- a/app/pages/PageLists.scala
+++ b/app/pages/PageLists.scala
@@ -43,12 +43,6 @@ object PageLists {
     SecondContactPhonePage
   )
 
-  val individualWithIDPages: Seq[QuestionPage[_]] = List(
-    IndWhatIsYourNINumberPage,
-    IndWhatIsYourNamePage,
-    IndDateOfBirthPage
-  )
-
   val individualAndWithoutIdPages: Seq[QuestionPage[_]] = List(
     WhatIsYourNamePage,
     IndWhereDoYouLivePage,


### PR DESCRIPTION
We do not need to clear the user info out when they land on this page. Removed the functionality that does that.