### PR TITLE
DAC6-3028: checkmode navigation fix

### DIFF
--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -271,10 +271,11 @@ class Navigator @Inject() () extends Logging {
       .getOrElse(controllers.routes.JourneyRecoveryController.onPageLoad())
 
   private def whatAreYouReportingAs(mode: Mode)(ua: UserAnswers): Call =
-    ua.get(ReporterTypePage) match {
-      case Some(Individual) => controllers.individual.routes.IndDoYouHaveNINumberController.onPageLoad(mode)
-      case Some(_)          => controllers.organisation.routes.RegisteredAddressInUKController.onPageLoad(mode)
-      case None             => controllers.routes.JourneyRecoveryController.onPageLoad()
+    (ua.get(ReporterTypePage), mode) match {
+      case (Some(Individual), NormalMode) => controllers.individual.routes.IndDoYouHaveNINumberController.onPageLoad(mode)
+      case (Some(Individual), CheckMode)  => controllers.routes.CheckYourAnswersController.onPageLoad()
+      case (Some(_), _)                   => controllers.organisation.routes.RegisteredAddressInUKController.onPageLoad(mode)
+      case (None, _)                      => controllers.routes.JourneyRecoveryController.onPageLoad()
     }
 
   private def doYouHaveUniqueTaxPayerReference(mode: Mode)(ua: UserAnswers): Call =

--- a/test/navigation/NavigatorSpec.scala
+++ b/test/navigation/NavigatorSpec.scala
@@ -602,6 +602,13 @@ class NavigatorSpec extends SpecBase with TableDrivenPropertyChecks with Generat
         navigator.nextPage(UnknownPage, CheckMode, UserAnswers("id")) mustBe routes.CheckYourAnswersController.onPageLoad
       }
 
+      "must go from ReporterTypePage" - {
+        "to Check Your Answers if Individual is unchanged" in {
+          val answers = emptyUserAnswers.withPage(ReporterTypePage, Individual)
+          navigator.nextPage(ReporterTypePage, CheckMode, answers) mustBe routes.CheckYourAnswersController.onPageLoad
+        }
+      }
+
       "must go from WhatIsYourUTRPage to WhatIsYourNamePage for a Sole Trader" in {
         val answers = emptyUserAnswers.withPage(ReporterTypePage, Sole)
 
@@ -823,7 +830,7 @@ class NavigatorSpec extends SpecBase with TableDrivenPropertyChecks with Generat
             .mustBe(routes.JourneyRecoveryController.onPageLoad())
         }
 
-        "to CheckYourAnswersPage if there is a contact emaile for a Sole reporter type" in {
+        "to CheckYourAnswersPage if there is a contact email for a Sole reporter type" in {
           val answers = emptyUserAnswers
             .withPage(ReporterTypePage, Sole)
             .withPage(IndContactEmailPage, arbitrary[String].sample.value)


### PR DESCRIPTION
if user type remains individual, checkmode routes back to check-your-answers