### PR TITLE
DAC6-3331: Modify address validation logic for individual user flow

### DIFF
--- a/app/utils/CheckYourAnswersValidator.scala
+++ b/app/utils/CheckYourAnswersValidator.scala
@@ -41,7 +41,7 @@ sealed trait IndividualAnswersValidator {
   private[utils] def checkIndividualContactDetailsMissingAnswers: Seq[Page] = checkPage(IndContactEmailPage).toSeq ++ checkIndPhoneAnswers
 
   private def checkIndividualAddressMissingAnswers: Seq[Page] = (userAnswers.get(IndWhereDoYouLivePage) match {
-    case Some(true) => checkPage(IndWhatIsYourPostcodePage)
+    case Some(true) => any(checkPage(IndWhatIsYourPostcodePage), checkPage(IndUKAddressWithoutIdPage))
         .orElse(
           any(
             checkPage(IndSelectAddressPage),


### PR DESCRIPTION
Update `checkIndividualAddressMissingAnswers` to include validation for `IndUKAddressWithoutIdPage` in addition to `IndWhatIsYourPostcodePage`. This ensures that the validation process considers both pages when checking individual address details.