### PR TITLE
DAC6-3367: Fix sole trader redirect

### DIFF
--- a/app/controllers/organisation/IsThisYourBusinessController.scala
+++ b/app/controllers/organisation/IsThisYourBusinessController.scala
@@ -76,7 +76,7 @@ class IsThisYourBusinessController @Inject() (
             case Right(response) =>
               handleRegistrationFound(mode, autoMatchedUtr, response)
             case Left(NotFoundError) =>
-              handleRegistrationNotFound(mode, autoMatchedUtr)
+              handleRegistrationNotFound(mode, autoMatchedUtr, request.userAnswers.get(ReporterTypePage).contains(Sole))
             case _ =>
               Future.successful(InternalServerError(errorView()))
           }
@@ -142,12 +142,17 @@ class IsThisYourBusinessController @Inject() (
 
   private def handleRegistrationNotFound(
     mode: Mode,
-    autoMatchedUtr: Option[UniqueTaxpayerReference]
+    autoMatchedUtr: Option[UniqueTaxpayerReference],
+    isSoleTrader: Boolean
   )(implicit request: DataRequest[AnyContent]): Future[Result] =
     if (autoMatchedUtr.nonEmpty) {
       resultWithAutoMatchedFieldCleared(mode)
     } else {
-      Future.successful(Redirect(controllers.organisation.routes.BusinessNotIdentifiedController.onPageLoad()))
+      if (isSoleTrader) {
+        Future.successful(Redirect(controllers.routes.SoleTraderNotIdentifiedController.onPageLoad))
+      } else {
+        Future.successful(Redirect(controllers.organisation.routes.BusinessNotIdentifiedController.onPageLoad()))
+      }
     }
 
   private def resultWithAutoMatchedFieldCleared(mode: Mode)(implicit request: DataRequest[AnyContent]): Future[Result] =

--- a/test/controllers/IsThisYourBusinessControllerSpec.scala
+++ b/test/controllers/IsThisYourBusinessControllerSpec.scala
@@ -162,6 +162,24 @@ class IsThisYourBusinessControllerSpec extends ControllerMockFixtures with Model
       redirectLocation(result).value mustEqual controllers.organisation.routes.BusinessNotIdentifiedController.onPageLoad().url
     }
 
+    "must redirect to SoleTraderNotIdentifiedController for a GET when there is no CT UTR and registration info not found" in {
+
+      when(mockMatchingService.sendBusinessRegistrationInformation(any())(any(), any()))
+        .thenReturn(Future.successful(Left(NotFoundError)))
+
+      when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any())).thenReturn(Future.successful(Right(OK)))
+      when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
+      when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(None))
+      retrieveUserAnswersData(validUserAnswers.withPage(ReporterTypePage, Sole).withPage(WhatIsYourNamePage, Name(FirstName, LastName)))
+
+      implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, loadRoute)
+
+      val result = route(mockedApp, request).value
+
+      status(result) mustEqual SEE_OTHER
+      redirectLocation(result).value mustEqual controllers.routes.SoleTraderNotIdentifiedController.onPageLoad.url
+    }
+
     "must return OK and the correct view for a GET when there is a CT UTR" in {
 
       val registrationInfo              = OrgRegistrationInfo(safeId, businessName, address)


### PR DESCRIPTION
Update redirection logic to handle missing CT UTR for sole traders. Added a new condition to redirect to SoleTraderNotIdentifiedController when appropriate. Updated tests to cover this new redirection path.