### PR TITLE
DAC6-3330: Update dependencies

### DIFF
--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,30 +2,30 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.1.0"
+  private val bootstrapVersion = "9.5.0"
   private val hmrcMongoVersion = "2.2.0"
 
   val compile = Seq[ModuleID](
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"     % "10.5.0",
-    "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30"  % "3.1.0",
-    "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"     % bootstrapVersion,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"             % hmrcMongoVersion,
-    "uk.gov.hmrc"       %% "domain-play-30"                 % "10.0.0",
-    "org.typelevel"     %% "cats-core"                      % "2.10.0",
-    "uk.gov.hmrc"       %% "crypto-json-play-30"            % "8.0.0"
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "10.13.0",
+    "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30" % "3.2.0",
+    "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"            % bootstrapVersion,
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"                    % hmrcMongoVersion,
+    "uk.gov.hmrc"       %% "domain-play-30"                        % "10.0.0",
+    "org.typelevel"     %% "cats-core"                             % "2.10.0",
+    "uk.gov.hmrc"       %% "crypto-json-play-30"                   % "8.1.0"
   )
 
   val test = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-test-play-30"  % bootstrapVersion,
-    "uk.gov.hmrc.mongo"       %% "hmrc-mongo-test-play-30" % hmrcMongoVersion,
-    "org.scalatestplus"       %% "scalacheck-1-15"         % "3.2.11.0",
-    "org.scalatestplus"       %% "mockito-3-4"             % "3.2.10.0",
-    "org.mockito"             %% "mockito-scala"           % "1.17.31",
-    "org.scalacheck"          %% "scalacheck"              % "1.18.0",
-    "org.pegdown"             %  "pegdown"                 % "1.6.0",
-    "org.jsoup"               %  "jsoup"                   % "1.17.2",
-    "wolfendale"             %%  "scalacheck-gen-regexp"   % "0.1.2",
+    "uk.gov.hmrc"                %% "bootstrap-test-play-30"  % bootstrapVersion,
+    "uk.gov.hmrc.mongo"          %% "hmrc-mongo-test-play-30" % hmrcMongoVersion,
+    "org.scalatestplus"          %% "scalacheck-1-15"         % "3.2.11.0",
+    "org.scalatestplus"          %% "mockito-3-4"             % "3.2.10.0",
+    "org.mockito"                %% "mockito-scala"           % "1.17.31",
+    "org.scalacheck"             %% "scalacheck"              % "1.18.0",
+    "org.pegdown"                 % "pegdown"                 % "1.6.0",
+    "org.jsoup"                   % "jsoup"                   % "1.17.2",
+    "wolfendale"                 %% "scalacheck-gen-regexp"   % "0.1.2",
     "com.softwaremill.quicklens" %% "quicklens"               % "1.9.7"
   ).map(_ % Test)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.22.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
 
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.4")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.5")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
 


### PR DESCRIPTION
Upgraded multiple dependencies in AppDependencies.scala for improved compatibility and stability, including bootstrap from 9.1.0 to 9.5.0 and play-frontend-hmrc-play from 10.5.0 to 10.13.0. Also updated the sbt-plugin in plugins.sbt from 3.0.4 to 3.0.5.