### PR TITLE
DAC6-3338: Change Verifiers for individuals

### DIFF
--- a/app/models/enrolment/SubscriptionInfo.scala
+++ b/app/models/enrolment/SubscriptionInfo.scala
@@ -51,17 +51,23 @@ object SubscriptionInfo {
     )
 
   private def getPostCodeIfProvided(userAnswers: UserAnswers): Option[String] =
-    (userAnswers.get(RegistrationInfoPage), userAnswers.get(NonUKBusinessAddressWithoutIDPage)) match {
-      case (Some(OrgRegistrationInfo(_, _, address)), _) => address.postalCode
-      case (_, Some(address))                            => address.postCode
-      case _                                             => None
+    (userAnswers.get(RegistrationInfoPage), userAnswers.get(NonUKBusinessAddressWithoutIDPage), userAnswers.get(IndUKAddressWithoutIdPage)) match {
+      case (Some(OrgRegistrationInfo(_, _, address)), _, _) => address.postalCode
+      case (_, Some(address), _)                            => address.postCode
+      case (_, _, Some(address))                            => address.postCode
+      case _                                                => None
     }
 
   private def getAbroadFlagIfProvided(userAnswers: UserAnswers): Option[String] =
-    (userAnswers.get(RegistrationInfoPage), userAnswers.get(NonUKBusinessAddressWithoutIDPage)) match {
-      case (Some(OrgRegistrationInfo(_, _, _)), _) => Some("N")
-      case (_, Some(_))                            => Some("Y")
-      case _                                       => None
+    (userAnswers.get(RegistrationInfoPage),
+     userAnswers.get(IndUKAddressWithoutIdPage),
+     userAnswers.get(NonUKBusinessAddressWithoutIDPage),
+     userAnswers.get(IndNonUKAddressWithoutIdPage)
+    ) match {
+      case (Some(OrgRegistrationInfo(_, _, _)), _, _, _) => Some("N")
+      case (_, Some(_), _, _)                            => Some("N")
+      case (_, _, Some(_), _) | (_, _, _, Some(_))       => Some("Y")
+      case _                                             => None
     }
 
 }

--- a/app/models/enrolment/SubscriptionInfo.scala
+++ b/app/models/enrolment/SubscriptionInfo.scala
@@ -18,7 +18,7 @@ package models.enrolment
 
 import models.IdentifierType._
 import models.matching.OrgRegistrationInfo
-import models.{SubscriptionID, UserAnswers}
+import models.{Address, SubscriptionID, UserAnswers}
 import pages._
 import play.api.libs.json.{Json, OFormat}
 
@@ -51,23 +51,24 @@ object SubscriptionInfo {
     )
 
   private def getPostCodeIfProvided(userAnswers: UserAnswers): Option[String] =
-    (userAnswers.get(RegistrationInfoPage), userAnswers.get(NonUKBusinessAddressWithoutIDPage), userAnswers.get(IndUKAddressWithoutIdPage)) match {
-      case (Some(OrgRegistrationInfo(_, _, address)), _, _) => address.postalCode
-      case (_, Some(address), _)                            => address.postCode
-      case (_, _, Some(address))                            => address.postCode
-      case _                                                => None
+    (userAnswers.get(RegistrationInfoPage), getAddress(userAnswers)) match {
+      case (Some(OrgRegistrationInfo(_, _, address)), _) => address.postalCode
+      case (_, Some(address))                            => address.postCode
+      case _                                             => None
     }
 
   private def getAbroadFlagIfProvided(userAnswers: UserAnswers): Option[String] =
-    (userAnswers.get(RegistrationInfoPage),
-     userAnswers.get(IndUKAddressWithoutIdPage),
-     userAnswers.get(NonUKBusinessAddressWithoutIDPage),
-     userAnswers.get(IndNonUKAddressWithoutIdPage)
-    ) match {
-      case (Some(OrgRegistrationInfo(_, _, _)), _, _, _) => Some("N")
-      case (_, Some(_), _, _)                            => Some("N")
-      case (_, _, Some(_), _) | (_, _, _, Some(_))       => Some("Y")
-      case _                                             => None
+    (userAnswers.get(RegistrationInfoPage), getAddress(userAnswers)) match {
+      case (Some(OrgRegistrationInfo(_, _, _)), _) => Some("N")
+      case (_, Some(address)) if address.isGB      => Some("N")
+      case (_, Some(address)) if !address.isGB     => Some("Y")
+      case _                                       => None
     }
+
+  private def getAddress(userAnswers: UserAnswers): Option[Address] =
+    userAnswers.get(IndUKAddressWithoutIdPage) orElse
+      userAnswers.get(IndNonUKAddressWithoutIdPage) orElse
+      userAnswers.get(NonUKBusinessAddressWithoutIDPage) orElse
+      userAnswers.get(IndSelectedAddressLookupPage).flatMap(_.toAddress)
 
 }

--- a/test/models/enrolment/SubscriptionInfoSpec.scala
+++ b/test/models/enrolment/SubscriptionInfoSpec.scala
@@ -16,20 +16,20 @@
 
 package models.enrolment
 
+import base.TestValues
 import generators.ModelGenerators
-import helpers.JsonFixtures.UserAnswersId
+import models.matching.{IndRegistrationInfo, OrgRegistrationInfo}
 import models.{Address, SubscriptionID, UserAnswers}
-import models.matching.OrgRegistrationInfo
 import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
-import pages.{NonUKBusinessAddressWithoutIDPage, RegistrationInfoPage}
+import pages.{IndNonUKAddressWithoutIdPage, IndUKAddressWithoutIdPage, NonUKBusinessAddressWithoutIDPage, RegistrationInfoPage}
 import play.api.libs.json.Json
 
 import java.time.{Clock, Instant, ZoneId}
 
-class SubscriptionInfoSpec extends AnyFreeSpec with Matchers with ModelGenerators with ScalaCheckPropertyChecks {
+class SubscriptionInfoSpec extends AnyFreeSpec with Matchers with ModelGenerators with ScalaCheckPropertyChecks with TestValues {
 
   def emptyUserAnswers: UserAnswers = UserAnswers(
     UserAnswersId,
@@ -72,6 +72,39 @@ class SubscriptionInfoSpec extends AnyFreeSpec with Matchers with ModelGenerator
       forAll {
         (address: Address, subscriptionId: SubscriptionID) =>
           val userAnswers      = emptyUserAnswers.set(NonUKBusinessAddressWithoutIDPage, address).success.value
+          val subscriptionInfo = SubscriptionInfo(userAnswers, subscriptionId)
+
+          subscriptionInfo.abroadFlag mustBe Some("Y")
+      }
+    }
+
+    "contains postCode for ind registration info" in {
+      forAll {
+        (address: Address, subscriptionId: SubscriptionID) =>
+          val userAnswers = emptyUserAnswers.set(RegistrationInfoPage, IndRegistrationInfo(safeId)).success.value
+            .set(IndUKAddressWithoutIdPage, address).success.value
+          val subscriptionInfo = SubscriptionInfo(userAnswers, subscriptionId)
+
+          subscriptionInfo.postCode mustBe address.postCode
+      }
+    }
+
+    "contains abroadFlag as N for ind registration info" in {
+      forAll {
+        (address: Address, subscriptionId: SubscriptionID) =>
+          val userAnswers = emptyUserAnswers.set(RegistrationInfoPage, IndRegistrationInfo(safeId)).success.value
+            .set(IndUKAddressWithoutIdPage, address).success.value
+          val subscriptionInfo = SubscriptionInfo(userAnswers, subscriptionId)
+
+          subscriptionInfo.abroadFlag mustBe Some("N")
+      }
+    }
+
+    "contains abroadFlag as Y for ind registration info" in {
+      forAll {
+        (address: Address, subscriptionId: SubscriptionID) =>
+          val userAnswers = emptyUserAnswers.set(RegistrationInfoPage, IndRegistrationInfo(safeId)).success.value
+            .set(IndNonUKAddressWithoutIdPage, address).success.value
           val subscriptionInfo = SubscriptionInfo(userAnswers, subscriptionId)
 
           subscriptionInfo.abroadFlag mustBe Some("Y")

--- a/test/models/enrolment/SubscriptionInfoSpec.scala
+++ b/test/models/enrolment/SubscriptionInfoSpec.scala
@@ -19,7 +19,7 @@ package models.enrolment
 import base.TestValues
 import generators.ModelGenerators
 import models.matching.{IndRegistrationInfo, OrgRegistrationInfo}
-import models.{Address, SubscriptionID, UserAnswers}
+import models.{Address, Country, SubscriptionID, UserAnswers}
 import org.scalatest.TryValues.convertTryToSuccessOrFailure
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
@@ -93,7 +93,7 @@ class SubscriptionInfoSpec extends AnyFreeSpec with Matchers with ModelGenerator
       forAll {
         (address: Address, subscriptionId: SubscriptionID) =>
           val userAnswers = emptyUserAnswers.set(RegistrationInfoPage, IndRegistrationInfo(safeId)).success.value
-            .set(IndUKAddressWithoutIdPage, address).success.value
+            .set(IndUKAddressWithoutIdPage, address.copy(country = Country.GB)).success.value
           val subscriptionInfo = SubscriptionInfo(userAnswers, subscriptionId)
 
           subscriptionInfo.abroadFlag mustBe Some("N")


### PR DESCRIPTION
Refactored SubscriptionInfo to include individual registration address information. Added tests to verify the inclusion of postcode and abroad flag for individual (Ind) registration info.