### PR TITLE
DAC6-3457: Rename regime constant

### DIFF
--- a/app/connectors/AddressLookupConnector.scala
+++ b/app/connectors/AddressLookupConnector.scala
@@ -17,7 +17,7 @@
 package connectors
 
 import config.FrontendAppConfig
-import models.Regime.CRSFATCA
+import models.Regime.CRFA
 import models.{AddressLookup, LookupAddressByPostcode}
 import play.api.Logging
 import play.api.http.Status._
@@ -39,7 +39,7 @@ class AddressLookupConnector @Inject() (http: HttpClient, config: FrontendAppCon
 
     val lookupAddressByPostcode = LookupAddressByPostcode(postCode, None)
 
-    http.POST[LookupAddressByPostcode, HttpResponse](addressLookupUrl, lookupAddressByPostcode, headers = Seq("X-Hmrc-Origin" -> CRSFATCA.toString)) flatMap {
+    http.POST[LookupAddressByPostcode, HttpResponse](addressLookupUrl, lookupAddressByPostcode, headers = Seq("X-Hmrc-Origin" -> CRFA.toString)) flatMap {
       case response if response.status equals OK =>
         Future.successful(
           sortAddresses(

--- a/app/models/Regime.scala
+++ b/app/models/Regime.scala
@@ -20,9 +20,9 @@ sealed trait Regime
 
 object Regime extends Enumerable.Implicits {
 
-  case object CRSFATCA extends WithName("CRSFATCA") with Regime
+  case object CRFA extends WithName("CRFA") with Regime
 
-  val values: Seq[Regime] = Seq(CRSFATCA)
+  val values: Seq[Regime] = Seq(CRFA)
 
   implicit val enumerable: Enumerable[Regime] =
     Enumerable(

--- a/app/models/register/request/RegisterWithID.scala
+++ b/app/models/register/request/RegisterWithID.scala
@@ -33,7 +33,7 @@ object RegisterWithID {
   ): RegisterWithID =
     RegisterWithID(
       RegisterWithIDRequest(
-        RequestCommon(Regime.CRSFATCA.toString),
+        RequestCommon(Regime.CRFA.toString),
         RequestWithIDDetails(name, dob, identifierName, identifierValue)
       )
     )
@@ -41,7 +41,7 @@ object RegisterWithID {
   def apply(registrationRequest: RegistrationRequest)(implicit uuidGenerator: UUIDGen, clock: Clock): RegisterWithID =
     RegisterWithID(
       RegisterWithIDRequest(
-        RequestCommon(Regime.CRSFATCA.toString),
+        RequestCommon(Regime.CRFA.toString),
         RequestWithIDDetails(registrationRequest)
       )
     )
@@ -49,7 +49,7 @@ object RegisterWithID {
   def apply(registrationRequest: AutoMatchedRegistrationRequest)(implicit uuidGenerator: UUIDGen, clock: Clock): RegisterWithID =
     RegisterWithID(
       RegisterWithIDRequest(
-        RequestCommon(Regime.CRSFATCA.toString),
+        RequestCommon(Regime.CRFA.toString),
         RequestWithIDDetails(registrationRequest)
       )
     )

--- a/app/models/register/request/RegisterWithoutID.scala
+++ b/app/models/register/request/RegisterWithoutID.scala
@@ -34,7 +34,7 @@ object RegisterWithoutID {
   def apply(name: Name, dob: LocalDate, address: Address, contactDetails: ContactDetails)(implicit uuidGen: UUIDGen, clock: Clock): RegisterWithoutID =
     RegisterWithoutID(
       RegisterWithoutIDRequest(
-        RequestCommon(Regime.CRSFATCA.toString),
+        RequestCommon(Regime.CRFA.toString),
         RequestWithoutIDDetails(None, Option(Individual(name, dob)), AddressRequest(address), contactDetails, None)
       )
     )
@@ -42,7 +42,7 @@ object RegisterWithoutID {
   def apply(organisationName: String, address: Address, contactDetails: ContactDetails)(implicit uuidGen: UUIDGen, clock: Clock): RegisterWithoutID =
     RegisterWithoutID(
       RegisterWithoutIDRequest(
-        RequestCommon(Regime.CRSFATCA.toString),
+        RequestCommon(Regime.CRFA.toString),
         RequestWithoutIDDetails(Option(organisationName).map(NoIdOrganisation(_)), None, AddressRequest(address), contactDetails, None)
       )
     )

--- a/test/connectors/RegistrationConnectorSpec.scala
+++ b/test/connectors/RegistrationConnectorSpec.scala
@@ -55,9 +55,9 @@ class RegistrationConnectorSpec extends SpecBase with WireMockServerHandler with
   val requestCommon: RequestCommon =
     RequestCommon(
       "2016-08-16T15:55:30Z",
-      Regime.CRSFATCA.toString,
+      Regime.CRFA.toString,
       "ec031b045855445e96f98a569ds56cd2",
-      Some(Seq(Parameters("REGIME", Regime.CRSFATCA.toString)))
+      Some(Seq(Parameters("REGIME", Regime.CRFA.toString)))
     )
 
   val registrationWithIndividualIDPayload: RegisterWithID = RegisterWithID(

--- a/test/helpers/JsonFixtures.scala
+++ b/test/helpers/JsonFixtures.scala
@@ -28,13 +28,13 @@ object JsonFixtures extends TestValues {
       |{
       |"registerWithIDRequest": {
       |"requestCommon": {
-      |"regime": "CRSFATCA",
+      |"regime": "CRFA",
       |"receiptDate": "2016-08-16T15:55:30Z",
       |"acknowledgementReference": "ec031b045855445e96f98a569ds56cd2",
       |"requestParameters": [
       |{
       |"paramName": "REGIME",
-      |"paramValue": "CRSFATCA"
+      |"paramValue": "CRFA"
       |}
       |]
       |},
@@ -56,13 +56,13 @@ object JsonFixtures extends TestValues {
   val registerWithIDJson: JsObject = Json.obj(
     "registerWithIDRequest" -> Json.obj(
       "requestCommon" -> Json.obj(
-        "regime"                   -> "CRSFATCA",
+        "regime"                   -> "CRFA",
         "receiptDate"              -> "2016-08-16T15:55:30Z",
         "acknowledgementReference" -> "ec031b045855445e96f98a569ds56cd2",
         "requestParameters" -> Json.arr(
           Json.obj(
             "paramName"  -> "REGIME",
-            "paramValue" -> "CRSFATCA"
+            "paramValue" -> "CRFA"
           )
         )
       ),
@@ -287,7 +287,7 @@ object JsonFixtures extends TestValues {
        |{
        |  "createSubscriptionRequest": {
        |    "requestCommon": {
-       |      "regime": "CRSFATCA",
+       |      "regime": "CRFA",
        |      "receiptDate": "2020-09-23T16:12:11Z",
        |      "acknowledgementReference": "AB123c",
        |      "originatingSystem": "MDTP",
@@ -317,7 +317,7 @@ object JsonFixtures extends TestValues {
       |{
       |  "createSubscriptionRequest": {
       |    "requestCommon": {
-      |      "regime": "CRSFATCA",
+      |      "regime": "CRFA",
       |      "receiptDate": "2020-09-23T16:12:11Z",
       |      "acknowledgementReference": "AB123c",
       |      "originatingSystem": "MDTP",
@@ -354,7 +354,7 @@ object JsonFixtures extends TestValues {
        |{
        |  "createSubscriptionRequest": {
        |    "requestCommon": {
-       |      "regime": "CRSFATCA",
+       |      "regime": "CRFA",
        |      "receiptDate": "2020-09-23T16:12:11Z",
        |      "acknowledgementReference": "AB123c",
        |      "originatingSystem": "MDTP"
@@ -394,7 +394,7 @@ object JsonFixtures extends TestValues {
        |{
        |  "createSubscriptionRequest": {
        |    "requestCommon": {
-       |      "regime": "CRSFATCA",
+       |      "regime": "CRFA",
        |      "receiptDate": "2020-09-23T16:12:11Z",
        |      "acknowledgementReference": "AB123c",
        |      "originatingSystem": "MDTP"
@@ -427,7 +427,7 @@ object JsonFixtures extends TestValues {
     Json.obj(
       "createSubscriptionRequest" -> Json.obj(
         "requestCommon" -> Json.obj(
-          "regime"                   -> "CRSFATCA",
+          "regime"                   -> "CRFA",
           "receiptDate"              -> "2020-09-23T16:12:11Z",
           "acknowledgementReference" -> "AB123c",
           "originatingSystem"        -> "MDTP",
@@ -457,7 +457,7 @@ object JsonFixtures extends TestValues {
     Json.obj(
       "createSubscriptionRequest" -> Json.obj(
         "requestCommon" -> Json.obj(
-          "regime"                   -> "CRSFATCA",
+          "regime"                   -> "CRFA",
           "receiptDate"              -> "2020-09-23T16:12:11Z",
           "acknowledgementReference" -> "AB123c",
           "originatingSystem"        -> "MDTP",
@@ -494,7 +494,7 @@ object JsonFixtures extends TestValues {
     Json.obj(
       "createSubscriptionRequest" -> Json.obj(
         "requestCommon" -> Json.obj(
-          "regime"                   -> "CRSFATCA",
+          "regime"                   -> "CRFA",
           "receiptDate"              -> "2020-09-23T16:12:11Z",
           "acknowledgementReference" -> "AB123c",
           "originatingSystem"        -> "MDTP"
@@ -532,7 +532,7 @@ object JsonFixtures extends TestValues {
     Json.obj(
       "createSubscriptionRequest" -> Json.obj(
         "requestCommon" -> Json.obj(
-          "regime"                   -> "CRSFATCA",
+          "regime"                   -> "CRFA",
           "receiptDate"              -> "2020-09-23T16:12:11Z",
           "acknowledgementReference" -> "AB123c",
           "originatingSystem"        -> "MDTP"
@@ -567,13 +567,13 @@ object JsonFixtures extends TestValues {
       |{
       |"registerWithoutIDRequest": {
       |"requestCommon": {
-      |"regime": "CRSFATCA",
+      |"regime": "CRFA",
       |"receiptDate": "2016-08-16T15:55:30Z",
       |"acknowledgementReference": "ec031b045855445e96f98a569ds56cd2",
       |"requestParameters": [
       |{
       |"paramName": "REGIME",
-      |"paramValue": "CRSFATCA"
+      |"paramValue": "CRFA"
       |}
       |]
       |},
@@ -609,13 +609,13 @@ object JsonFixtures extends TestValues {
   val registerWithoutIDJson: JsObject = Json.obj(
     "registerWithoutIDRequest" -> Json.obj(
       "requestCommon" -> Json.obj(
-        "regime"                   -> "CRSFATCA",
+        "regime"                   -> "CRFA",
         "receiptDate"              -> "2016-08-16T15:55:30Z",
         "acknowledgementReference" -> "ec031b045855445e96f98a569ds56cd2",
         "requestParameters" -> Json.arr(
           Json.obj(
             "paramName"  -> "REGIME",
-            "paramValue" -> "CRSFATCA"
+            "paramValue" -> "CRFA"
           )
         )
       ),


### PR DESCRIPTION
Updated regime constant from CRSFATCA to CRFA across the codebase. This change ensures consistency with the new regime naming conventions.