### PR TITLE
DAC6-3508: Refactor subscription handling

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -79,7 +79,8 @@ class FrontendAppConfig @Inject() (configuration: Configuration) {
   val ctEnrolmentKey: String       = configuration.get[String]("keys.enrolmentKey.ct")
   lazy val countryCodeJson: String = configuration.get[String]("json.countries")
 
-  val cacheTtl: Int = configuration.get[Int]("mongodb.timeToLiveInSeconds")
+  val cacheTtl: Int        = configuration.get[Int]("mongodb.timeToLiveInSeconds")
+  val subscriptionTtl: Int = configuration.get[Int]("mongodb.subscriptionTimeToLiveInSeconds")
 
   val userAnswersEncryptionEnabled: Boolean = configuration.get[Boolean]("mongodb.encryptionEnabled")
 }

--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -68,7 +68,7 @@ class CheckYourAnswersController @Inject() (
       val result = for {
         safeId         <- EitherT(getSafeIdFromRegistration())
         subscriptionID <- EitherT(subscriptionService.checkAndCreateSubscription(safeId, request.userAnswers, request.affinityGroup))
-        result         <- EitherT.right[ApiError](controllerHelper.updateSubscriptionIdAndCreateEnrolment(subscriptionID))
+        result         <- EitherT.right[ApiError](controllerHelper.updateSubscriptionIdAndCreateEnrolment(safeId, subscriptionID))
       } yield result
 
       result.valueOrF {

--- a/app/controllers/individual/IndIdentityConfirmedController.scala
+++ b/app/controllers/individual/IndIdentityConfirmedController.scala
@@ -71,8 +71,8 @@ class IndIdentityConfirmedController @Inject() (
                 case Right(info) =>
                   request.userAnswers.set(RegistrationInfoPage, info).map(sessionRepository.set)
                   subscriptionService.getSubscription(info.safeId) flatMap {
-                    case Some(displaySubscriptionResponse) =>
-                      controllerHelper.updateSubscriptionIdAndCreateEnrolment(displaySubscriptionResponse.subscriptionId)
+                    case Some(subscriptionID) =>
+                      controllerHelper.updateSubscriptionIdAndCreateEnrolment(info.safeId, subscriptionID)
                     case _ =>
                       val action = navigator.nextPage(RegistrationInfoPage, mode, request.userAnswers).url
                       Future.successful(Ok(view(mode, action)))

--- a/app/controllers/organisation/IsThisYourBusinessController.scala
+++ b/app/controllers/organisation/IsThisYourBusinessController.scala
@@ -113,8 +113,8 @@ class IsThisYourBusinessController @Inject() (
     request: DataRequest[AnyContent]
   ): Future[Result] =
     subscriptionService.getSubscription(registrationInfo.safeId) flatMap {
-      case Some(displaySubscriptionResponse) =>
-        controllerHelper.updateSubscriptionIdAndCreateEnrolment(displaySubscriptionResponse.subscriptionId)
+      case Some(subscriptionId) =>
+        controllerHelper.updateSubscriptionIdAndCreateEnrolment(registrationInfo.safeId, subscriptionId)
       case _ =>
         val preparedForm = request.userAnswers.get(IsThisYourBusinessPage) match {
           case None        => form

--- a/app/models/UserSubscription.scala
+++ b/app/models/UserSubscription.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.functional.syntax._
+import play.api.libs.json._
+import uk.gov.hmrc.crypto.Sensitive.SensitiveString
+import uk.gov.hmrc.crypto.json.JsonEncryption
+import uk.gov.hmrc.crypto.{Decrypter, Encrypter}
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+
+import java.time.Instant
+
+final case class UserSubscription(
+  id: String,
+  subscriptionID: SubscriptionID,
+  lastUpdated: Instant = Instant.now
+)
+
+object UserSubscription {
+
+  implicit def format(encryptionEnabled: Boolean)(implicit crypto: Encrypter with Decrypter): OFormat[UserSubscription] =
+    if (encryptionEnabled) encryptedFormat else plainFormat
+
+  private def plainFormat: OFormat[UserSubscription] = {
+    val reads: Reads[UserSubscription] =
+      (
+        (__ \ "_id").read[String] and
+          (__ \ "subscriptionID").read[SubscriptionID] and
+          (__ \ "lastUpdated").read(MongoJavatimeFormats.instantFormat)
+      )(UserSubscription.apply _)
+
+    val writes: OWrites[UserSubscription] =
+      (
+        (__ \ "_id").write[String] and
+          (__ \ "subscriptionID").write[SubscriptionID] and
+          (__ \ "lastUpdated").write(MongoJavatimeFormats.instantFormat)
+      )(unlift(UserSubscription.unapply))
+
+    OFormat(reads, writes)
+  }
+
+  private def encryptedFormat(implicit crypto: Encrypter with Decrypter): OFormat[UserSubscription] = {
+
+    implicit val sensitiveFormat: Format[SensitiveString] =
+      JsonEncryption.sensitiveEncrypterDecrypter(SensitiveString.apply)
+
+    val encryptedReads: Reads[UserSubscription] =
+      (
+        (__ \ "_id").read[String] and
+          (__ \ "subscriptionID").read[SensitiveString] and
+          (__ \ "lastUpdated").read(MongoJavatimeFormats.instantFormat)
+      )(
+        (id, subscriptionID, lastUpdated) =>
+          UserSubscription(id, SubscriptionID(subscriptionID.decryptedValue), lastUpdated)
+      )
+
+    val encryptedWrites: OWrites[UserSubscription] =
+      (
+        (__ \ "_id").write[String] and
+          (__ \ "subscriptionID").write[SensitiveString] and
+          (__ \ "lastUpdated").write(MongoJavatimeFormats.instantFormat)
+      )(
+        userSubscription => (userSubscription.id, SensitiveString(userSubscription.subscriptionID.value), userSubscription.lastUpdated)
+      )
+
+    OFormat(encryptedReads, encryptedWrites)
+  }
+
+}

--- a/app/models/crypto/SensitiveJsObject.scala
+++ b/app/models/crypto/SensitiveJsObject.scala
@@ -20,3 +20,5 @@ import play.api.libs.json.JsObject
 import uk.gov.hmrc.crypto.Sensitive
 
 case class SensitiveJsObject(override val decryptedValue: JsObject) extends Sensitive[JsObject]
+
+case class SensitiveString(override val decryptedValue: String) extends Sensitive[String]

--- a/app/repositories/SubscriptionRepository.scala
+++ b/app/repositories/SubscriptionRepository.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import config.FrontendAppConfig
+import models.UserSubscription
+import org.mongodb.scala.bson.conversions.Bson
+import org.mongodb.scala.model._
+import play.api.libs.json.Format
+import uk.gov.hmrc.crypto.{Decrypter, Encrypter}
+import uk.gov.hmrc.mongo.MongoComponent
+import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+
+import java.time.{Clock, Instant}
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubscriptionRepository @Inject() (
+  mongoComponent: MongoComponent,
+  appConfig: FrontendAppConfig,
+  clock: Clock
+)(implicit ec: ExecutionContext, crypto: Encrypter with Decrypter)
+    extends PlayMongoRepository[UserSubscription](
+      collectionName = "user-subscription",
+      mongoComponent = mongoComponent,
+      domainFormat = UserSubscription.format(appConfig.userAnswersEncryptionEnabled),
+      indexes = Seq(
+        IndexModel(
+          Indexes.ascending("lastUpdated"),
+          IndexOptions()
+            .name("subscriptionLastUpdatedIdx")
+            .expireAfter(appConfig.subscriptionTtl, java.util.concurrent.TimeUnit.SECONDS)
+        )
+      )
+    ) {
+
+  implicit val instantFormat: Format[Instant] = MongoJavatimeFormats.instantFormat
+
+  private def byId(id: String): Bson = Filters.equal("_id", id)
+
+  def keepAlive(id: String): Future[Boolean] =
+    collection
+      .updateOne(
+        filter = byId(id),
+        update = Updates.set("lastUpdated", Instant.now(clock))
+      )
+      .toFuture()
+      .map(
+        _ => true
+      )
+
+  def get(id: String): Future[Option[UserSubscription]] =
+    keepAlive(id).flatMap {
+      _ =>
+        collection
+          .find(byId(id))
+          .headOption()
+    }
+
+  def set(subscription: UserSubscription): Future[Boolean] = {
+
+    val updatedSubscription = subscription copy (lastUpdated = Instant.now(clock))
+
+    collection
+      .replaceOne(
+        filter = byId(updatedSubscription.id),
+        replacement = updatedSubscription,
+        options = ReplaceOptions().upsert(true)
+      )
+      .toFuture()
+      .map(
+        _ => true
+      )
+  }
+
+  def clear(id: String): Future[Boolean] =
+    collection
+      .deleteOne(byId(id))
+      .toFuture()
+      .map(
+        _ => true
+      )
+
+}

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -91,6 +91,7 @@ mongodb {
   uri                 = "mongodb://localhost:27017/"${appName}
   timeToLiveInSeconds = 900
   encryptionEnabled   = true
+  subscriptionTimeToLiveInSeconds = 2419200
 }
 
 urls {

--- a/it/test/repositories/EncryptedSubscriptionRepositorySpec.scala
+++ b/it/test/repositories/EncryptedSubscriptionRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@
 package repositories
 
 import config.FrontendAppConfig
-import models.UserAnswers
+import models.crypto.SensitiveString
+import models.{SubscriptionID, UserSubscription}
 import org.mockito.Mockito.when
 import org.mongodb.scala.bson.BsonDocument
 import org.mongodb.scala.model.Filters
@@ -27,21 +28,21 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.Configuration
-import play.api.libs.json.Format.GenericFormat
-import play.api.libs.json.Json
-import uk.gov.hmrc.crypto.{Decrypter, Encrypter, SymmetricCryptoFactory}
+import play.api.libs.json.{Format, JsString, Json}
+import uk.gov.hmrc.crypto.json.JsonEncryption
+import uk.gov.hmrc.crypto.{Crypted, Decrypter, Encrypter, SymmetricCryptoFactory}
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 
 import java.security.SecureRandom
-import java.time.{Clock, Instant, ZoneId}
 import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant, ZoneId}
 import java.util.Base64
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class SessionRepositorySpec
+class EncryptedSubscriptionRepositorySpec
     extends AnyFreeSpec
     with Matchers
-    with DefaultPlayMongoRepositorySupport[UserAnswers]
+    with DefaultPlayMongoRepositorySupport[UserSubscription]
     with ScalaFutures
     with IntegrationPatience
     with OptionValues
@@ -50,11 +51,11 @@ class SessionRepositorySpec
   private val instant          = Instant.now.truncatedTo(ChronoUnit.MILLIS)
   private val stubClock: Clock = Clock.fixed(instant, ZoneId.systemDefault)
 
-  private val userAnswers = UserAnswers("id", Json.obj("foo" -> "bar"), Instant.ofEpochSecond(1))
+  private val userSubscription = UserSubscription("id", SubscriptionID("subscriptionID"), Instant.ofEpochSecond(1))
 
   private val mockAppConfig = mock[FrontendAppConfig]
-  when(mockAppConfig.cacheTtl) thenReturn 1
-  when(mockAppConfig.userAnswersEncryptionEnabled) thenReturn false
+  when(mockAppConfig.subscriptionTtl) thenReturn 1
+  when(mockAppConfig.userAnswersEncryptionEnabled) thenReturn true
 
   private val aesKey = {
     val keyLength = 32
@@ -68,7 +69,10 @@ class SessionRepositorySpec
   implicit private val crypto: Encrypter with Decrypter =
     SymmetricCryptoFactory.aesGcmCryptoFromConfig("crypto", configuration.underlying)
 
-  override protected val repository = new SessionRepository(
+  implicit val sensitiveFormat: Format[SensitiveString] =
+    JsonEncryption.sensitiveEncrypterDecrypter(SensitiveString.apply)
+
+  override protected val repository = new SubscriptionRepository(
     mongoComponent = mongoComponent,
     appConfig = mockAppConfig,
     clock = stubClock
@@ -77,30 +81,30 @@ class SessionRepositorySpec
   ".set" - {
 
     "must set the last updated time on the supplied user answers to `now`, and save them" in {
-      val expectedResult = userAnswers copy (lastUpdated = instant)
+      val expectedResult = userSubscription copy (lastUpdated = instant)
 
-      val setResult     = repository.set(userAnswers).futureValue
-      val updatedRecord = find(Filters.equal("_id", userAnswers.id)).futureValue.headOption.value
+      val setResult     = repository.set(userSubscription).futureValue
+      val updatedRecord = find(Filters.equal("_id", userSubscription.id)).futureValue.headOption.value
 
       setResult mustEqual true
       updatedRecord mustEqual expectedResult
     }
 
-    "must persist the data in plain format" in {
-      val setResult = repository.set(userAnswers).futureValue
+    "must persist the data in encrypted format" in {
+      val setResult = repository.set(userSubscription).futureValue
 
       setResult mustEqual true
 
       val retrievedRecord = repository.collection
-        .find[BsonDocument](Filters.and(Filters.equal("_id", userAnswers.id)))
+        .find[BsonDocument](Filters.and(Filters.equal("_id", userSubscription.id)))
         .headOption()
         .futureValue
         .value
 
-      val json = Json.parse(retrievedRecord.toJson)
-      (json \ "data").get mustBe userAnswers.data
+      val rawData       = retrievedRecord.get("subscriptionID").asString().getValue
+      val decryptedData = crypto.decrypt(Crypted(rawData)).value
+      Json.parse(decryptedData) mustBe JsString(userSubscription.subscriptionID.value)
     }
-
   }
 
   ".get" - {
@@ -109,10 +113,10 @@ class SessionRepositorySpec
 
       "must update the lastUpdated time and get the record" in {
 
-        insert(userAnswers).futureValue
+        insert(userSubscription).futureValue
 
-        val result         = repository.get(userAnswers.id).futureValue
-        val expectedResult = userAnswers copy (lastUpdated = instant)
+        val result         = repository.get(userSubscription.id).futureValue
+        val expectedResult = userSubscription copy (lastUpdated = instant)
 
         result.value mustEqual expectedResult
       }
@@ -131,12 +135,12 @@ class SessionRepositorySpec
 
     "must remove a record" in {
 
-      insert(userAnswers).futureValue
+      insert(userSubscription).futureValue
 
-      val result = repository.clear(userAnswers.id).futureValue
+      val result = repository.clear(userSubscription.id).futureValue
 
       result mustEqual true
-      repository.get(userAnswers.id).futureValue must not be defined
+      repository.get(userSubscription.id).futureValue must not be defined
     }
 
     "must return true when there is no record to remove" in {
@@ -152,14 +156,14 @@ class SessionRepositorySpec
 
       "must update its lastUpdated to `now` and return true" in {
 
-        insert(userAnswers).futureValue
+        insert(userSubscription).futureValue
 
-        val result = repository.keepAlive(userAnswers.id).futureValue
+        val result = repository.keepAlive(userSubscription.id).futureValue
 
-        val expectedUpdatedAnswers = userAnswers copy (lastUpdated = instant)
+        val expectedUpdatedAnswers = userSubscription copy (lastUpdated = instant)
 
         result mustEqual true
-        val updatedAnswers = find(Filters.equal("_id", userAnswers.id)).futureValue.headOption.value
+        val updatedAnswers = find(Filters.equal("_id", userSubscription.id)).futureValue.headOption.value
         updatedAnswers mustEqual expectedUpdatedAnswers
       }
     }

--- a/it/test/repositories/SubscriptionRepositorySpec.scala
+++ b/it/test/repositories/SubscriptionRepositorySpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package repositories
 
 import config.FrontendAppConfig
-import models.UserAnswers
+import models.{SubscriptionID, UserSubscription}
 import org.mockito.Mockito.when
 import org.mongodb.scala.bson.BsonDocument
 import org.mongodb.scala.model.Filters
@@ -27,21 +27,20 @@ import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.Configuration
-import play.api.libs.json.Format.GenericFormat
-import play.api.libs.json.Json
+import play.api.libs.json.{JsString, Json}
 import uk.gov.hmrc.crypto.{Decrypter, Encrypter, SymmetricCryptoFactory}
 import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 
 import java.security.SecureRandom
-import java.time.{Clock, Instant, ZoneId}
 import java.time.temporal.ChronoUnit
+import java.time.{Clock, Instant, ZoneId}
 import java.util.Base64
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class SessionRepositorySpec
+class SubscriptionRepositorySpec
     extends AnyFreeSpec
     with Matchers
-    with DefaultPlayMongoRepositorySupport[UserAnswers]
+    with DefaultPlayMongoRepositorySupport[UserSubscription]
     with ScalaFutures
     with IntegrationPatience
     with OptionValues
@@ -50,10 +49,10 @@ class SessionRepositorySpec
   private val instant          = Instant.now.truncatedTo(ChronoUnit.MILLIS)
   private val stubClock: Clock = Clock.fixed(instant, ZoneId.systemDefault)
 
-  private val userAnswers = UserAnswers("id", Json.obj("foo" -> "bar"), Instant.ofEpochSecond(1))
+  private val userSubscription = UserSubscription("id", SubscriptionID("subscriptionID"), Instant.ofEpochSecond(1))
 
   private val mockAppConfig = mock[FrontendAppConfig]
-  when(mockAppConfig.cacheTtl) thenReturn 1
+  when(mockAppConfig.subscriptionTtl) thenReturn 1
   when(mockAppConfig.userAnswersEncryptionEnabled) thenReturn false
 
   private val aesKey = {
@@ -68,39 +67,37 @@ class SessionRepositorySpec
   implicit private val crypto: Encrypter with Decrypter =
     SymmetricCryptoFactory.aesGcmCryptoFromConfig("crypto", configuration.underlying)
 
-  override protected val repository = new SessionRepository(
+  override protected val repository = new SubscriptionRepository(
     mongoComponent = mongoComponent,
     appConfig = mockAppConfig,
     clock = stubClock
   )
 
   ".set" - {
-
     "must set the last updated time on the supplied user answers to `now`, and save them" in {
-      val expectedResult = userAnswers copy (lastUpdated = instant)
+      val expectedResult = userSubscription copy (lastUpdated = instant)
 
-      val setResult     = repository.set(userAnswers).futureValue
-      val updatedRecord = find(Filters.equal("_id", userAnswers.id)).futureValue.headOption.value
+      val setResult     = repository.set(userSubscription).futureValue
+      val updatedRecord = find(Filters.equal("_id", userSubscription.id)).futureValue.headOption.value
 
       setResult mustEqual true
       updatedRecord mustEqual expectedResult
     }
 
     "must persist the data in plain format" in {
-      val setResult = repository.set(userAnswers).futureValue
+      val setResult = repository.set(userSubscription).futureValue
 
       setResult mustEqual true
 
       val retrievedRecord = repository.collection
-        .find[BsonDocument](Filters.and(Filters.equal("_id", userAnswers.id)))
+        .find[BsonDocument](Filters.and(Filters.equal("_id", userSubscription.id)))
         .headOption()
         .futureValue
         .value
 
       val json = Json.parse(retrievedRecord.toJson)
-      (json \ "data").get mustBe userAnswers.data
+      (json \ "subscriptionID" \ "value").get mustBe JsString(userSubscription.subscriptionID.value)
     }
-
   }
 
   ".get" - {
@@ -109,20 +106,20 @@ class SessionRepositorySpec
 
       "must update the lastUpdated time and get the record" in {
 
-        insert(userAnswers).futureValue
+        insert(userSubscription).futureValue
 
-        val result         = repository.get(userAnswers.id).futureValue
-        val expectedResult = userAnswers copy (lastUpdated = instant)
+        val result         = repository.get(userSubscription.id).futureValue
+        val expectedResult = userSubscription copy (lastUpdated = instant)
 
         result.value mustEqual expectedResult
       }
-    }
 
-    "when there is no record for this id" - {
+      "when there is no record for this id" - {
 
-      "must return None" in {
+        "must return None" in {
 
-        repository.get("id that does not exist").futureValue must not be defined
+          repository.get("id that does not exist").futureValue must not be defined
+        }
       }
     }
   }
@@ -131,12 +128,12 @@ class SessionRepositorySpec
 
     "must remove a record" in {
 
-      insert(userAnswers).futureValue
+      insert(userSubscription).futureValue
 
-      val result = repository.clear(userAnswers.id).futureValue
+      val result = repository.clear(userSubscription.id).futureValue
 
       result mustEqual true
-      repository.get(userAnswers.id).futureValue must not be defined
+      repository.get(userSubscription.id).futureValue must not be defined
     }
 
     "must return true when there is no record to remove" in {
@@ -152,14 +149,14 @@ class SessionRepositorySpec
 
       "must update its lastUpdated to `now` and return true" in {
 
-        insert(userAnswers).futureValue
+        insert(userSubscription).futureValue
 
-        val result = repository.keepAlive(userAnswers.id).futureValue
+        val result = repository.keepAlive(userSubscription.id).futureValue
 
-        val expectedUpdatedAnswers = userAnswers copy (lastUpdated = instant)
+        val expectedUpdatedAnswers = userSubscription copy (lastUpdated = instant)
 
         result mustEqual true
-        val updatedAnswers = find(Filters.equal("_id", userAnswers.id)).futureValue.headOption.value
+        val updatedAnswers = find(Filters.equal("_id", userSubscription.id)).futureValue.headOption.value
         updatedAnswers mustEqual expectedUpdatedAnswers
       }
     }

--- a/test/controllers/ControllerHelperSpec.scala
+++ b/test/controllers/ControllerHelperSpec.scala
@@ -33,6 +33,7 @@ import pages._
 import play.api.inject.bind
 import play.api.mvc.{AnyContent, Result}
 import play.api.test.Helpers._
+import repositories.SubscriptionRepository
 import services.TaxEnrolmentService
 import uk.gov.hmrc.auth.core.AffinityGroup
 import uk.gov.hmrc.http.HeaderCarrier
@@ -41,13 +42,15 @@ import scala.concurrent.Future
 
 class ControllerHelperSpec extends SpecBase with ControllerMockFixtures with BeforeAndAfterEach {
 
-  val mockTaxEnrolmentService: TaxEnrolmentService = mock[TaxEnrolmentService]
+  val mockTaxEnrolmentService: TaxEnrolmentService       = mock[TaxEnrolmentService]
+  val mockSubscriptionRepository: SubscriptionRepository = mock[SubscriptionRepository]
 
   override def beforeEach(): Unit =
-    reset(mockTaxEnrolmentService)
+    reset(mockTaxEnrolmentService, mockSubscriptionRepository)
 
   private val application = applicationBuilder()
     .overrides(bind[TaxEnrolmentService].toInstance(mockTaxEnrolmentService))
+    .overrides(bind[SubscriptionRepository].toInstance(mockSubscriptionRepository))
     .build()
 
   val controller: ControllerHelper = application.injector.instanceOf[ControllerHelper]
@@ -68,8 +71,9 @@ class ControllerHelperSpec extends SpecBase with ControllerMockFixtures with Bef
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any()))
         .thenReturn(Future.successful(Right(1)))
       when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
+      when(mockSubscriptionRepository.clear(any())).thenReturn(Future.successful(true))
 
-      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(subscriptionId)(HeaderCarrier(), dataRequest)
+      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(safeId, subscriptionId)(HeaderCarrier(), dataRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(routes.RegistrationConfirmationController.onPageLoad().url)
@@ -85,8 +89,9 @@ class ControllerHelperSpec extends SpecBase with ControllerMockFixtures with Bef
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any()))
         .thenReturn(Future.successful(Left(EnrolmentExistsError(mock[GroupIds]))))
       when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
+      when(mockSubscriptionRepository.set(any())).thenReturn(Future.successful(true))
 
-      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(subscriptionId)(HeaderCarrier(), dataRequest)
+      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(safeId, subscriptionId)(HeaderCarrier(), dataRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(controllers.individual.routes.IndividualAlreadyRegisteredController.onPageLoad().url)
@@ -103,8 +108,9 @@ class ControllerHelperSpec extends SpecBase with ControllerMockFixtures with Bef
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any()))
         .thenReturn(Future.successful(Left(EnrolmentExistsError(mock[GroupIds]))))
       when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
+      when(mockSubscriptionRepository.set(any())).thenReturn(Future.successful(true))
 
-      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(subscriptionId)(HeaderCarrier(), dataRequest)
+      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(safeId, subscriptionId)(HeaderCarrier(), dataRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(controllers.individual.routes.IndividualAlreadyRegisteredController.onPageLoad().url)
@@ -122,8 +128,9 @@ class ControllerHelperSpec extends SpecBase with ControllerMockFixtures with Bef
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any()))
         .thenReturn(Future.successful(Left(EnrolmentExistsError(mock[GroupIds]))))
       when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
+      when(mockSubscriptionRepository.set(any())).thenReturn(Future.successful(true))
 
-      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(subscriptionId)(HeaderCarrier(), dataRequest)
+      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(safeId, subscriptionId)(HeaderCarrier(), dataRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(routes.PreRegisteredController.onPageLoad(withId = true).url)
@@ -139,8 +146,9 @@ class ControllerHelperSpec extends SpecBase with ControllerMockFixtures with Bef
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any()))
         .thenReturn(Future.successful(Left(EnrolmentExistsError(mock[GroupIds]))))
       when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
+      when(mockSubscriptionRepository.set(any())).thenReturn(Future.successful(true))
 
-      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(subscriptionId)(HeaderCarrier(), dataRequest)
+      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(safeId, subscriptionId)(HeaderCarrier(), dataRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(routes.PreRegisteredController.onPageLoad(withId = false).url)
@@ -156,8 +164,9 @@ class ControllerHelperSpec extends SpecBase with ControllerMockFixtures with Bef
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any()))
         .thenReturn(Future.successful(Left(MandatoryInformationMissingError("Error"))))
       when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
+      when(mockSubscriptionRepository.set(any())).thenReturn(Future.successful(true))
 
-      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(subscriptionId)(HeaderCarrier(), dataRequest)
+      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(safeId, subscriptionId)(HeaderCarrier(), dataRequest)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(routes.InformationMissingController.onPageLoad().url)
@@ -173,8 +182,9 @@ class ControllerHelperSpec extends SpecBase with ControllerMockFixtures with Bef
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any()))
         .thenReturn(Future.successful(Left(ApiError.ServiceUnavailableError)))
       when(mockSessionRepository.set(any())).thenReturn(Future.successful(true))
+      when(mockSubscriptionRepository.set(any())).thenReturn(Future.successful(true))
 
-      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(subscriptionId)(HeaderCarrier(), dataRequest)
+      val result: Future[Result] = controller.updateSubscriptionIdAndCreateEnrolment(safeId, subscriptionId)(HeaderCarrier(), dataRequest)
 
       status(result) shouldBe SERVICE_UNAVAILABLE
 

--- a/test/controllers/IsThisYourBusinessControllerSpec.scala
+++ b/test/controllers/IsThisYourBusinessControllerSpec.scala
@@ -25,8 +25,7 @@ import models.error.ApiError.{BadRequestError, NotFoundError, ServiceUnavailable
 import models.matching.{AutoMatchedRegistrationRequest, OrgRegistrationInfo, RegistrationRequest, SafeId}
 import models.register.request.RegisterWithID
 import models.register.response.details.AddressResponse
-import models.subscription.response.DisplaySubscriptionResponse
-import models.{Name, NormalMode, UUIDGen, UniqueTaxpayerReference, UserAnswers}
+import models.{Name, NormalMode, SubscriptionID, UUIDGen, UniqueTaxpayerReference, UserAnswers}
 import org.mockito.ArgumentMatchers.{any, eq => mockitoEq}
 import org.mockito.Mockito.{reset, when}
 import org.scalacheck.Arbitrary
@@ -108,7 +107,7 @@ class IsThisYourBusinessControllerSpec extends ControllerMockFixtures with Model
 
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any())).thenReturn(Future.successful(Right(OK)))
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
-      when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(None))
+      when(mockSubscriptionService.getSubscription(any[SafeId]())(any())).thenReturn(Future.successful(None))
       retrieveUserAnswersData(validUserAnswers)
 
       implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, loadRoute)
@@ -151,7 +150,7 @@ class IsThisYourBusinessControllerSpec extends ControllerMockFixtures with Model
 
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any())).thenReturn(Future.successful(Right(OK)))
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
-      when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(None))
+      when(mockSubscriptionService.getSubscription(any[SafeId]())(any())).thenReturn(Future.successful(None))
       retrieveUserAnswersData(validUserAnswers)
 
       implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, loadRoute)
@@ -169,7 +168,7 @@ class IsThisYourBusinessControllerSpec extends ControllerMockFixtures with Model
 
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any())).thenReturn(Future.successful(Right(OK)))
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
-      when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(None))
+      when(mockSubscriptionService.getSubscription(any[SafeId]())(any())).thenReturn(Future.successful(None))
       retrieveUserAnswersData(validUserAnswers.withPage(ReporterTypePage, Sole).withPage(WhatIsYourNamePage, Name(FirstName, LastName)))
 
       implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, loadRoute)
@@ -200,7 +199,7 @@ class IsThisYourBusinessControllerSpec extends ControllerMockFixtures with Model
 
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any())).thenReturn(Future.successful(Right(OK)))
       when(mockSessionRepository.set(mockitoEq(updatedUserAnswer))) thenReturn Future.successful(true)
-      when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(None))
+      when(mockSubscriptionService.getSubscription(any[SafeId]())(any())).thenReturn(Future.successful(None))
       retrieveUserAnswersData(userAnswersWithAutoMatchedUtr)
 
       implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, loadRoute)
@@ -225,7 +224,7 @@ class IsThisYourBusinessControllerSpec extends ControllerMockFixtures with Model
 
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any())).thenReturn(Future.successful(Right(OK)))
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
-      when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(None))
+      when(mockSubscriptionService.getSubscription(any[SafeId]())(any())).thenReturn(Future.successful(None))
       retrieveUserAnswersData(userAnswersWithoutReporterType)
 
       implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, loadRoute)
@@ -252,7 +251,7 @@ class IsThisYourBusinessControllerSpec extends ControllerMockFixtures with Model
 
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any())).thenReturn(Future.successful(Right(OK)))
       when(mockSessionRepository.set(mockitoEq(userAnswersWithAutoMatchedFieldCleared))) thenReturn Future.successful(true)
-      when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(None))
+      when(mockSubscriptionService.getSubscription(any[SafeId]())(any())).thenReturn(Future.successful(None))
       retrieveUserAnswersData(userAnswersWithAutoMatchedUtr)
 
       implicit val request: FakeRequest[AnyContentAsEmpty.type] = FakeRequest(GET, loadRoute)
@@ -271,7 +270,7 @@ class IsThisYourBusinessControllerSpec extends ControllerMockFixtures with Model
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any())).thenReturn(Future.successful(Right(OK)))
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
 
-      when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(None))
+      when(mockSubscriptionService.getSubscription(any[SafeId]())(any())).thenReturn(Future.successful(None))
 
       val updatedUserAnswers: UserAnswers = emptyUserAnswers
         .set(ReporterTypePage, Sole)
@@ -296,12 +295,12 @@ class IsThisYourBusinessControllerSpec extends ControllerMockFixtures with Model
     }
 
     "render technical difficulties page when there is an existing subscription and fails to create an enrolment" in {
-      forAll(Arbitrary.arbitrary[DisplaySubscriptionResponse]) {
+      forAll(Arbitrary.arbitrary[SubscriptionID]) {
         subscription =>
           when(mockMatchingService.sendBusinessRegistrationInformation(any())(any(), any()))
             .thenReturn(Future.successful(Right(OrgRegistrationInfo(safeId, OrgName, address))))
 
-          when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(Some(subscription)))
+          when(mockSubscriptionService.getSubscription(any[SafeId]())(any())).thenReturn(Future.successful(Some(subscription)))
           when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any())).thenReturn(Future.successful(Left(BadRequestError)))
           when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
 
@@ -325,7 +324,7 @@ class IsThisYourBusinessControllerSpec extends ControllerMockFixtures with Model
       when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any())).thenReturn(Future.successful(Right(OK)))
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
 
-      when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(None))
+      when(mockSubscriptionService.getSubscription(any[SafeId]())(any())).thenReturn(Future.successful(None))
 
       val userAnswers: UserAnswers = validUserAnswers
         .set(IsThisYourBusinessPage, true)

--- a/test/controllers/individual/IndIdentityConfirmedControllerSpec.scala
+++ b/test/controllers/individual/IndIdentityConfirmedControllerSpec.scala
@@ -21,8 +21,7 @@ import controllers.routes
 import generators.ModelGenerators
 import models.error.ApiError.{BadRequestError, NotFoundError, ServiceUnavailableError}
 import models.matching.{IndRegistrationInfo, SafeId}
-import models.subscription.response.DisplaySubscriptionResponse
-import models.{Name, NormalMode, UserAnswers}
+import models.{Name, NormalMode, SubscriptionID, UserAnswers}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, when}
 import org.scalacheck.Arbitrary
@@ -84,7 +83,7 @@ class IndIdentityConfirmedControllerSpec extends SpecBase with ControllerMockFix
       when(mockMatchingService.sendIndividualRegistrationInformation(any())(any(), any()))
         .thenReturn(Future.successful(Right(registrationInfo)))
 
-      when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(None))
+      when(mockSubscriptionService.getSubscription(any[SafeId]())(any())).thenReturn(Future.successful(None))
 
       when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
 
@@ -100,11 +99,11 @@ class IndIdentityConfirmedControllerSpec extends SpecBase with ControllerMockFix
 
     "must redirect to registration confirmation page when there is an existing subscription" in {
 
-      forAll(Arbitrary.arbitrary[DisplaySubscriptionResponse]) {
+      forAll(Arbitrary.arbitrary[SubscriptionID]) {
         subscription =>
           when(mockMatchingService.sendIndividualRegistrationInformation(any())(any(), any()))
             .thenReturn(Future.successful(Right(registrationInfo)))
-          when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(Some(subscription)))
+          when(mockSubscriptionService.getSubscription(any[SafeId]())(any())).thenReturn(Future.successful(Some(subscription)))
           when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any())).thenReturn(Future.successful(Right(OK)))
 
           when(mockSessionRepository.set(any())) thenReturn Future.successful(true)
@@ -122,11 +121,11 @@ class IndIdentityConfirmedControllerSpec extends SpecBase with ControllerMockFix
 
     "render technical difficulties page when there is an existing subscription and fails to create an enrolment" in {
 
-      forAll(Arbitrary.arbitrary[DisplaySubscriptionResponse]) {
+      forAll(Arbitrary.arbitrary[SubscriptionID]) {
         subscription =>
           when(mockMatchingService.sendIndividualRegistrationInformation(any())(any(), any()))
             .thenReturn(Future.successful(Right(registrationInfo)))
-          when(mockSubscriptionService.getSubscription(any[SafeId]())(any(), any())).thenReturn(Future.successful(Some(subscription)))
+          when(mockSubscriptionService.getSubscription(any[SafeId]())(any())).thenReturn(Future.successful(Some(subscription)))
           when(mockTaxEnrolmentService.checkAndCreateEnrolment(any(), any())(any(), any())).thenReturn(Future.successful(Left(BadRequestError)))
 
           when(mockSessionRepository.set(any())) thenReturn Future.successful(true)


### PR DESCRIPTION
Replaced `DisplaySubscriptionResponse` with `SubscriptionID` across the codebase for streamlined subscription handling. Added `UserSubscription` model and integrated `SubscriptionRepository` to manage encrypted subscription data. Updated relevant tests to reflect these changes.