### PR TITLE
DAC6-3536: Update action set

### DIFF
--- a/app/controllers/RegistrationConfirmationController.scala
+++ b/app/controllers/RegistrationConfirmationController.scala
@@ -40,7 +40,7 @@ class RegistrationConfirmationController @Inject() (
     extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = standardActionSets.identifiedUserWithData() async {
+  def onPageLoad: Action[AnyContent] = standardActionSets.identifiedWithoutEnrolmentCheck() async {
     implicit request =>
       sessionRepository.set(request.userAnswers.copy(data = Json.obj())).flatMap {
         case true => Future.successful(Ok(view()))


### PR DESCRIPTION
Replace `identifiedUserWithData()` with `identifiedWithoutEnrolmentCheck()` in `onPageLoad`. This change ensures the enrolment check is bypassed while maintaining the rest of the user identification flow.