### PR TITLE
DAC6-3536: Add redirect control to IdentifierAction

### DIFF
--- a/app/controllers/RegistrationConfirmationController.scala
+++ b/app/controllers/RegistrationConfirmationController.scala
@@ -40,7 +40,7 @@ class RegistrationConfirmationController @Inject() (
     extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = standardActionSets.identifiedWithoutEnrolmentCheck() async {
+  def onPageLoad: Action[AnyContent] = standardActionSets.identifiedWithoutEnrolmentCheckAndWithoutRedirect() async {
     implicit request =>
       sessionRepository.set(request.userAnswers.copy(data = Json.obj())).flatMap {
         case true => Future.successful(Ok(view()))

--- a/app/controllers/actions/StandardActionSets.scala
+++ b/app/controllers/actions/StandardActionSets.scala
@@ -40,6 +40,9 @@ class StandardActionSets @Inject() (identify: IdentifierAction,
   def identifiedUserWithEnrolmentCheckAndCtUtrRetrieval(): ActionBuilder[IdentifierRequest, AnyContent] =
     identify() andThen checkEnrolment andThen retrieveCtUTR()
 
+  def identifiedWithoutEnrolmentCheckAndWithoutRedirect(): ActionBuilder[DataRequest, AnyContent] =
+    identify(redirect = false) andThen getData() andThen requireData
+
   def identifiedWithoutEnrolmentCheck(): ActionBuilder[DataRequest, AnyContent] =
     identify() andThen getData() andThen requireData
 

--- a/test/controllers/actions/FakeIdentifierAction.scala
+++ b/test/controllers/actions/FakeIdentifierAction.scala
@@ -37,6 +37,6 @@ class FakeIdentifierAction @Inject() (bodyParsers: PlayBodyParsers, affinityGrou
   override protected def executionContext: ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global
 
-  override def apply(): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest] = this
+  override def apply(redirect: Boolean = true): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest] = this
 
 }


### PR DESCRIPTION
Introduce a `redirect` parameter in `IdentifierAction` and related classes to control redirection behavior. Update `StandardActionSets` with a new method for handling actions without enrolment checks and disabling redirects. Adjust corresponding logic in `RegistrationConfirmationController` to use the new functionality.