### PR TITLE
DAC6-3539: Refactor subscription handling

### DIFF
--- a/app/controllers/ControllerHelper.scala
+++ b/app/controllers/ControllerHelper.scala
@@ -105,9 +105,9 @@ class ControllerHelper @Inject() (
     request: DataRequest[AnyContent]
   ): Future[Result] =
     for {
+      result         <- createEnrolment(safeId, request.userAnswers, subscriptionId)
       updatedAnswers <- Future.fromTry(request.userAnswers.set(SubscriptionIDPage, subscriptionId))
       _              <- sessionRepository.set(updatedAnswers)
-      result         <- createEnrolment(safeId, request.userAnswers, subscriptionId)
     } yield result
 
 }

--- a/app/controllers/RegistrationConfirmationController.scala
+++ b/app/controllers/RegistrationConfirmationController.scala
@@ -46,8 +46,8 @@ class RegistrationConfirmationController @Inject() (
         subscriptionId <- Future.successful(request.userAnswers.get(SubscriptionIDPage))
         clearSession   <- sessionRepository.set(request.userAnswers.copy(data = Json.obj()))
       } yield (subscriptionId, clearSession) match {
-        case (Some(fatcaId), true)  => Ok(view(fatcaId.value))
-        case (None, _) | (_, false) => Ok(errorView())
+        case (Some(fatcaId), true) => Ok(view(fatcaId.value))
+        case _                     => Ok(errorView())
       }
   }
 

--- a/app/views/RegistrationConfirmationView.scala.html
+++ b/app/views/RegistrationConfirmationView.scala.html
@@ -27,7 +27,7 @@
         appConfig: FrontendAppConfig
 )
 
-@(userId: String = "ABCD123456")(implicit request: Request[_], messages: Messages)
+@(fatcaId: String)(implicit request: Request[_], messages: Messages)
 
 @addFILink = {@link(appConfig.addFinancialInstitutionUrl, messages("registrationConfirmation.link.addFI"))}
 @surveyLink = {@link(appConfig.exitSurveyUrl, messages("registrationConfirmation.link.survey"))}
@@ -36,7 +36,7 @@
 
     @govukPanel(Panel(
         title = Text(messages("registrationConfirmation.heading")),
-        content = HtmlContent(s"Your CRS and FATCA user ID \n <b>$userId</b>")
+        content = HtmlContent(s"Your CRS and FATCA user ID \n <b>$fatcaId</b>")
 
         )
     )


### PR DESCRIPTION
Reordered `createEnrolment` invocation to ensure user answers are updated after enrollment is created. Replaced `userId` with `fatcaId` in RegistrationConfirmationView and updated view rendering logic accordingly. Enhanced tests to validate scenarios with missing or invalid SubscriptionID.