### PR TITLE
DAC6-3538: Enable autoComplete

### DIFF
--- a/.g8/checkboxPage/app/views/$className$View.scala.html
+++ b/.g8/checkboxPage/app/views/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value_0")))

--- a/.g8/checkboxPagePkg/app/views/$packageName$/$className$View.scala.html
+++ b/.g8/checkboxPagePkg/app/views/$packageName$/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value_0")))

--- a/.g8/datePage/app/views/$className$View.scala.html
+++ b/.g8/datePage/app/views/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value.day")))

--- a/.g8/datePagePkg/app/views/$packageName$/$className$View.scala.html
+++ b/.g8/datePagePkg/app/views/$packageName$/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("value" -> "value.day")))

--- a/.g8/intPage/app/views/$className$View.scala.html
+++ b/.g8/intPage/app/views/$className$View.scala.html
@@ -12,7 +12,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/.g8/intPagePkg/app/views/$packageName$/$className$View.scala.html
+++ b/.g8/intPagePkg/app/views/$packageName$/$className$View.scala.html
@@ -12,7 +12,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/.g8/multipleQuestionsPage/app/views/$className$View.scala.html
+++ b/.g8/multipleQuestionsPage/app/views/$className$View.scala.html
@@ -12,7 +12,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/.g8/multipleQuestionsPagePkg/app/views/$packageName$/$className$View.scala.html
+++ b/.g8/multipleQuestionsPagePkg/app/views/$packageName$/$className$View.scala.html
@@ -12,7 +12,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/.g8/radioButtonPage/app/views/$className$View.scala.html
+++ b/.g8/radioButtonPage/app/views/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autocomplete") -> "on") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))

--- a/.g8/radioButtonPage/app/views/$className$View.scala.html
+++ b/.g8/radioButtonPage/app/views/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), 'autoComplete -> "off") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autocomplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))

--- a/.g8/radioButtonPagePkg/app/views/$packageName$/$className$View.scala.html
+++ b/.g8/radioButtonPagePkg/app/views/$packageName$/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), 'autoComplete -> "off") {
+    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autocomplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))

--- a/.g8/radioButtonPagePkg/app/views/$packageName$/$className$View.scala.html
+++ b/.g8/radioButtonPagePkg/app/views/$packageName$/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autocomplete") -> "on") {
+    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("value" -> "value_0")))

--- a/.g8/yesNoPage/app/views/$className$View.scala.html
+++ b/.g8/yesNoPage/app/views/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/.g8/yesNoPagePkg/app/views/$packageName$/$className$View.scala.html
+++ b/.g8/yesNoPagePkg/app/views/$packageName$/$className$View.scala.html
@@ -10,7 +10,7 @@
 
 @layout(pageTitle = title(form, messages("$className;format="decap"$.title"))) {
 
-    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.$packageName$.routes.$className$Controller.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/CheckYourAnswersView.scala.html
+++ b/app/views/CheckYourAnswersView.scala.html
@@ -47,7 +47,7 @@
         <p class="govuk-body">@messages("checkYourAnswers.information.p")</p>
     </div>
 
-    @formHelper(action = routes.CheckYourAnswersController.onSubmit(), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.CheckYourAnswersController.onSubmit(), Symbol("autoComplete") -> "on") {
         @govukButton(
             ButtonViewModel(messages("checkYourAnswers.button")).withAttribute("id" -> "submit").preventingDoubleClick()
         )

--- a/app/views/DoYouHaveUTRView.scala.html
+++ b/app/views/DoYouHaveUTRView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("doYouHaveUniqueTaxPayerReference.title"))) {
 
-    @formHelper(action = routes.DoYouHaveUniqueTaxPayerReferenceController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = routes.DoYouHaveUniqueTaxPayerReferenceController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/ReporterTypeView.scala.html
+++ b/app/views/ReporterTypeView.scala.html
@@ -27,7 +27,7 @@
 
 @layout(pageTitle = title(form, messages("reporterType.title"))) {
 
-    @formHelper(action = routes.ReporterTypeController.onSubmit(mode), Symbol("autocomplete") -> "on") {
+    @formHelper(action = routes.ReporterTypeController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/ReporterTypeView.scala.html
+++ b/app/views/ReporterTypeView.scala.html
@@ -27,7 +27,7 @@
 
 @layout(pageTitle = title(form, messages("reporterType.title"))) {
 
-    @formHelper(action = routes.ReporterTypeController.onSubmit(mode), 'autoComplete -> "off") {
+    @formHelper(action = routes.ReporterTypeController.onSubmit(mode), Symbol("autocomplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/changeContactDetails/IndividualHavePhoneView.scala.html
+++ b/app/views/changeContactDetails/IndividualHavePhoneView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("individualHavePhone.title"))) {
 
-    @formHelper(action = controllers.changeContactDetails.routes.IndividualHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.changeContactDetails.routes.IndividualHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/changeContactDetails/OrganisationContactHavePhoneView.scala.html
+++ b/app/views/changeContactDetails/OrganisationContactHavePhoneView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("organisationContactHavePhone.title"))) {
 
-    @formHelper(action = controllers.changeContactDetails.routes.OrganisationContactHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.changeContactDetails.routes.OrganisationContactHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/changeContactDetails/OrganisationHaveSecondContactView.scala.html
+++ b/app/views/changeContactDetails/OrganisationHaveSecondContactView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("organisationHaveSecondContact.title"))) {
 
-    @formHelper(action = controllers.changeContactDetails.routes.OrganisationHaveSecondContactController.onSubmit(mode), Symbol("autocomplete") -> "on") {
+    @formHelper(action = controllers.changeContactDetails.routes.OrganisationHaveSecondContactController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/changeContactDetails/OrganisationHaveSecondContactView.scala.html
+++ b/app/views/changeContactDetails/OrganisationHaveSecondContactView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("organisationHaveSecondContact.title"))) {
 
-    @formHelper(action = controllers.changeContactDetails.routes.OrganisationHaveSecondContactController.onSubmit(mode), 'autoComplete -> "off") {
+    @formHelper(action = controllers.changeContactDetails.routes.OrganisationHaveSecondContactController.onSubmit(mode), Symbol("autocomplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/changeContactDetails/OrganisationSecondContactHavePhoneView.scala.html
+++ b/app/views/changeContactDetails/OrganisationSecondContactHavePhoneView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("organisationSecondContactHavePhone.title"))) {
 
-    @formHelper(action = controllers.changeContactDetails.routes.OrganisationSecondContactHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.changeContactDetails.routes.OrganisationSecondContactHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/individual/IndContactHavePhoneView.scala.html
+++ b/app/views/individual/IndContactHavePhoneView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("indContactHavePhone.title"))) {
 
-    @formHelper(action = controllers.individual.routes.IndContactHavePhoneController.onSubmit(mode), Symbol("autocomplete") -> "on") {
+    @formHelper(action = controllers.individual.routes.IndContactHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/individual/IndContactHavePhoneView.scala.html
+++ b/app/views/individual/IndContactHavePhoneView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("indContactHavePhone.title"))) {
 
-    @formHelper(action = controllers.individual.routes.IndContactHavePhoneController.onSubmit(mode), 'autoComplete -> "off") {
+    @formHelper(action = controllers.individual.routes.IndContactHavePhoneController.onSubmit(mode), Symbol("autocomplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/individual/IndContactNameView.scala.html
+++ b/app/views/individual/IndContactNameView.scala.html
@@ -28,7 +28,7 @@
 
 @layout(pageTitle = title(form, messages("indContactName.title"))) {
 
-    @formHelper(action = controllers.individual.routes.IndContactNameController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.individual.routes.IndContactNameController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/individual/IndDoYouHaveNINumberView.scala.html
+++ b/app/views/individual/IndDoYouHaveNINumberView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("indDoYouHaveNINumber.title"))) {
 
-    @formHelper(action = controllers.individual.routes.IndDoYouHaveNINumberController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.individual.routes.IndDoYouHaveNINumberController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/individual/IndIsThisYourAddressView.scala.html
+++ b/app/views/individual/IndIsThisYourAddressView.scala.html
@@ -28,7 +28,7 @@
 
 @layout(pageTitle = title(form, messages("isThisYourAddress.title"))) {
 
-    @formHelper(action = controllers.individual.routes.IndIsThisYourAddressController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.individual.routes.IndIsThisYourAddressController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/individual/IndNonUkAddressWithoutIdView.scala.html
+++ b/app/views/individual/IndNonUkAddressWithoutIdView.scala.html
@@ -33,7 +33,7 @@
 
 @layout(pageTitle = title(form, messages(s"addressWithoutId.individual.title"))) {
 
-    @formHelper(action = controllers.individual.routes.IndNonUKAddressWithoutIdController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.individual.routes.IndNonUKAddressWithoutIdController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/individual/IndSelectAddressView.scala.html
+++ b/app/views/individual/IndSelectAddressView.scala.html
@@ -30,7 +30,7 @@ appConfig: FrontendAppConfig
 
 @layout(pageTitle = title(form, messages("indSelectAddress.title"))) {
 
-@formHelper(action = controllers.individual.routes.IndSelectAddressController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+@formHelper(action = controllers.individual.routes.IndSelectAddressController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
        @if(form.errors.nonEmpty) {
            @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/individual/IndUKAddressWithoutIdView.scala.html
+++ b/app/views/individual/IndUKAddressWithoutIdView.scala.html
@@ -33,7 +33,7 @@
 
 @layout(pageTitle = title(form, messages(s"addressWithoutId.individual.title"))) {
 
-    @formHelper(action = controllers.individual.routes.IndUKAddressWithoutIdController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.individual.routes.IndUKAddressWithoutIdController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/individual/IndWhatIsYourNameView.scala.html
+++ b/app/views/individual/IndWhatIsYourNameView.scala.html
@@ -30,7 +30,7 @@
 
 @layout(pageTitle = title(form, messages("indWhatIsYourName.title"))) {
 
-    @formHelper(action = controllers.individual.routes.IndWhatIsYourNameController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.individual.routes.IndWhatIsYourNameController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/organisation/ContactHavePhoneView.scala.html
+++ b/app/views/organisation/ContactHavePhoneView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("contactHavePhone.title"))) {
 
-    @formHelper(action = controllers.organisation.routes.ContactHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.organisation.routes.ContactHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/organisation/HaveSecondContactView.scala.html
+++ b/app/views/organisation/HaveSecondContactView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("haveSecondContact.title"))) {
 
-    @formHelper(action = controllers.organisation.routes.HaveSecondContactController.onSubmit(mode), 'autoComplete -> "off") {
+    @formHelper(action = controllers.organisation.routes.HaveSecondContactController.onSubmit(mode), Symbol("autocomplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/organisation/HaveSecondContactView.scala.html
+++ b/app/views/organisation/HaveSecondContactView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("haveSecondContact.title"))) {
 
-    @formHelper(action = controllers.organisation.routes.HaveSecondContactController.onSubmit(mode), Symbol("autocomplete") -> "on") {
+    @formHelper(action = controllers.organisation.routes.HaveSecondContactController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/organisation/HaveTradingNameView.scala.html
+++ b/app/views/organisation/HaveTradingNameView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("haveTradingName.title"))) {
 
-    @formHelper(action = controllers.organisation.routes.HaveTradingNameController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.organisation.routes.HaveTradingNameController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/organisation/IsThisYourBusinessView.scala.html
+++ b/app/views/organisation/IsThisYourBusinessView.scala.html
@@ -28,7 +28,7 @@
 
 @layout(pageTitle = title(form, messages("isThisYourBusiness.title"))) {
 
-    @formHelper(action = controllers.organisation.routes.IsThisYourBusinessController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.organisation.routes.IsThisYourBusinessController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/organisation/NonUKBusinessAddressWithoutIDView.scala.html
+++ b/app/views/organisation/NonUKBusinessAddressWithoutIDView.scala.html
@@ -33,7 +33,7 @@
 
     @layout(pageTitle = title(form, messages(s"addressWithoutId.business.title"))) {
 
-        @formHelper(action = controllers.organisation.routes.NonUKBusinessAddressWithoutIDController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+        @formHelper(action = controllers.organisation.routes.NonUKBusinessAddressWithoutIDController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
             @if(form.errors.nonEmpty) {
                 @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/organisation/RegisteredAddressInUKView.scala.html
+++ b/app/views/organisation/RegisteredAddressInUKView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("registeredAddressInUK.title"))) {
 
-    @formHelper(action = controllers.organisation.routes.RegisteredAddressInUKController.onSubmit(mode), 'autoComplete -> "off") {
+    @formHelper(action = controllers.organisation.routes.RegisteredAddressInUKController.onSubmit(mode), Symbol("autocomplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/organisation/RegisteredAddressInUKView.scala.html
+++ b/app/views/organisation/RegisteredAddressInUKView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("registeredAddressInUK.title"))) {
 
-    @formHelper(action = controllers.organisation.routes.RegisteredAddressInUKController.onSubmit(mode), Symbol("autocomplete") -> "on") {
+    @formHelper(action = controllers.organisation.routes.RegisteredAddressInUKController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/organisation/SecondContactHavePhoneView.scala.html
+++ b/app/views/organisation/SecondContactHavePhoneView.scala.html
@@ -26,7 +26,7 @@
 
 @layout(pageTitle = title(form, messages("secondContactHavePhone.title"))) {
 
-    @formHelper(action = controllers.organisation.routes.SecondContactHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.organisation.routes.SecondContactHavePhoneController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))

--- a/app/views/organisation/WhatIsYourNameView.scala.html
+++ b/app/views/organisation/WhatIsYourNameView.scala.html
@@ -32,7 +32,7 @@
 
 @layout(pageTitle = title(form, messages("whatIsYourName.title"))) {
 
-    @formHelper(action = controllers.organisation.routes.WhatIsYourNameController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.organisation.routes.WhatIsYourNameController.onSubmit(mode), Symbol("autoComplete") -> "on") {
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form))


### PR DESCRIPTION
Updated formHelper calls across multiple views to set the autoComplete attribute to "on" instead of "off". This ensures better user experience by allowing browsers to suggest or prefill form fields where applicable.