### PR TITLE
DAC6-3580: Set autocomplete attribute

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -42,6 +42,13 @@ function updateAccessibleAutocompleteStyling(originalSelect) {
                 }
             }
         }
+        if (originalSelect && originalSelect.getAttribute('autocomplete') > "") {
+            if (parentForm) {
+                if (combo) {
+                    combo.setAttribute('autocomplete', originalSelect.getAttribute('autocomplete'));
+                }
+            }
+        }
         // =====================================================
         // Update autocomplete once loaded with error styling if needed
         // This won't work if the autocomplete css is loaded after the frontend library css because


### PR DESCRIPTION
Add logic to propagate the autocomplete attribute from the original select element to the combo element if it exists. Ensures better compatibility and adherence to form input behavior expectations.