### PR TITLE
Dac6-3570 : Updated dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sbt test
 
 Run integration tests:
 ```
-sbt it:test
+sbt it/test
 ```
 
 ---

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,18 +2,18 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.5.0"
-  private val hmrcMongoVersion = "2.2.0"
+  private val bootstrapVersion = "9.11.0"
+  private val hmrcMongoVersion = "2.5.0"
 
   val compile = Seq[ModuleID](
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "10.13.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "11.12.0",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30" % "3.2.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"            % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"                    % hmrcMongoVersion,
     "uk.gov.hmrc"       %% "domain-play-30"                        % "10.0.0",
     "org.typelevel"     %% "cats-core"                             % "2.10.0",
-    "uk.gov.hmrc"       %% "crypto-json-play-30"                   % "8.1.0"
+    "uk.gov.hmrc"       %% "crypto-json-play-30"                   % "8.2.0"
   )
 
   val test = Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,9 +14,9 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
 
-addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.5")
+addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
 


### PR DESCRIPTION

org.playframework:sbt-plugin 3.0.5  -> 3.0.6
uk.gov.hmrc: sbt-distributables 2.5.0 -> 2.6.0
uk.gov.hmrc.mongo: hmrc-mongo-play-30 2.2.0 -> 2.5.0
uk.gov.hmrc: bootstrap-frontend-play-30 9.5.0 -> 9.11.0
uk.gov.hmrc: crypto-json-play-30 8.1.0 -> 8.2.0
uk.gov.hmrc: play-frontend-hmrc-play-30 10.13.0 -> 11.12.0
uk.gov.hmrc.mongo: hmrc-mongo-test-play-30 2.2.0 -> 2.5.0
uk.gov.hmrc: bootstrap-test-play-30 9.5.0. -> 9.11.0