### PR TITLE
DAC6-3581: Remove redundant form submission logic

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -77,36 +77,6 @@ function updateAccessibleAutocompleteStyling(originalSelect) {
             }
         }
 
-        // =====================================================
-        // Ensure when user replaces valid answer with a non-valid answer, then valid answer is not retained
-        // =====================================================
-        var holdSubmit = true;
-        parentForm.addEventListener('submit', function (e) {
-            if (holdSubmit) {
-                e.preventDefault()
-                if (originalSelect.querySelectorAll('[selected]').length > 0 || originalSelect.value > "") {
-
-                    var resetSelect = false;
-
-                    if (originalSelect.value) {
-                        if (combo.value != originalSelect.querySelector('option[value="' + originalSelect.value + '"]').text) {
-                            resetSelect = true;
-                        }
-                    }
-                    if (resetSelect) {
-                        originalSelect.value = "";
-                        if (originalSelect.querySelectorAll('[selected]').length > 0) {
-                            originalSelect.querySelectorAll('[selected]')[0].removeAttribute('selected');
-                        }
-                    }
-                }
-
-                holdSubmit = false;
-                //parentForm.submit();
-                HTMLFormElement.prototype.submit.call(parentForm); // because submit buttons have id of "submit" which masks the form's natural form.submit() function
-            }
-        })
-
     }
 
     function checkForAutocompleteLoad() {

--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -105,6 +105,14 @@ function upTo(el, tagName) {
 
 var countrySelect = document.querySelector('select#country');
 if (countrySelect !== null) {
+    var options = countrySelect.querySelectorAll("option");
+    for (var i = 0; i < options.length; i++) {
+        var option = options[i];
+        var dataText = option.getAttribute('data-text');
+        if (dataText) {
+            option.text = dataText;
+        }
+    }
     HMRCAccessibleAutocomplete.enhanceSelectElement({
         defaultValue: '',
         selectElement: countrySelect,

--- a/app/utils/CountryListFactory.scala
+++ b/app/utils/CountryListFactory.scala
@@ -79,8 +79,9 @@ class CountryListFactory @Inject() (environment: Environment, appConfig: Fronten
         val isSelected = value.get("country").contains(country.code)
         SelectItem(
           Some(country.code),
-          if (isSelected) country.description else names.mkString(":"),
-          isSelected
+          country.description,
+          isSelected,
+          attributes = Map("data-text" -> (if (isSelected) country.description else names.mkString(":")))
         )
     }.toSeq.sortBy(_.text)
     SelectItem(Some(""), "Select a country", selected = false) +: countryJsonList

--- a/test/utils/CountryListFactorySpec.scala
+++ b/test/utils/CountryListFactorySpec.scala
@@ -159,8 +159,8 @@ class CountryListFactorySpec extends SpecBase {
 
       factory.countrySelectList(Map.empty, countries) must contain theSameElementsAs Seq(
         SelectItem(Some(""), "Select a country"),
-        SelectItem(value = Some("AB"), text = "Country_1", selected = false),
-        SelectItem(value = Some("BC"), text = "Country_2", selected = false)
+        SelectItem(value = Some("AB"), text = "Country_1", selected = false, attributes = Map("data-text" -> "Country_1")),
+        SelectItem(value = Some("BC"), text = "Country_2", selected = false, attributes = Map("data-text" -> "Country_2"))
       )
     }
 
@@ -175,8 +175,8 @@ class CountryListFactorySpec extends SpecBase {
 
       factory.countrySelectList(selectedCountry, countries) must contain theSameElementsAs Seq(
         SelectItem(value = Some(""), text = "Select a country"),
-        SelectItem(value = Some("AB"), text = "Country_1:Country_1_2", selected = false),
-        SelectItem(value = Some("BC"), text = "Country_2", selected = true)
+        SelectItem(value = Some("AB"), text = "Country_1", selected = false, attributes = Map("data-text" -> "Country_1:Country_1_2")),
+        SelectItem(value = Some("BC"), text = "Country_2", selected = true, attributes = Map("data-text" -> "Country_2"))
       )
     }
 
@@ -191,8 +191,8 @@ class CountryListFactorySpec extends SpecBase {
 
       factory.countrySelectList(selectedCountry, countries) must contain theSameElementsAs Seq(
         SelectItem(value = Some(""), text = "Select a country"),
-        SelectItem(value = Some("AB"), text = "Country_1:Country_1_2", selected = false),
-        SelectItem(value = Some("BC"), text = "Country_2", selected = false)
+        SelectItem(value = Some("AB"), text = "Country_1", selected = false, attributes = Map("data-text" -> "Country_1:Country_1_2")),
+        SelectItem(value = Some("BC"), text = "Country_2", selected = false, attributes = Map("data-text" -> "Country_2"))
       )
     }
   }


### PR DESCRIPTION
Deleted obsolete code handling form submission to ensure cleaner and more maintainable scripts. The logic was no longer necessary and could cause unexpected behavior under certain conditions.