### PR TITLE
DAC6-3581: Delay autocomplete init

### DIFF
--- a/app/assets/javascripts/app.js
+++ b/app/assets/javascripts/app.js
@@ -113,27 +113,29 @@ if (countrySelect !== null) {
             option.text = dataText;
         }
     }
-    HMRCAccessibleAutocomplete.enhanceSelectElement({
-        defaultValue: '',
-        selectElement: countrySelect,
-        showAllValues: true,
-        autoSelect: false,
-        templates: {
-            suggestion: function (suggestion) {
-                if (suggestion) {
-                    return suggestion.split(':')[0];
+    setTimeout(function(){
+        HMRCAccessibleAutocomplete.enhanceSelectElement({
+            defaultValue: '',
+            selectElement: countrySelect,
+            showAllValues: true,
+            autoSelect: false,
+            templates: {
+                suggestion: function (suggestion) {
+                    if (suggestion) {
+                        return suggestion.split(':')[0];
+                    }
+                    return suggestion;
+                },
+                inputValue: function (suggestion) {
+                    if (suggestion) {
+                        return suggestion.split(':')[0];
+                    }
+                    return suggestion;
                 }
-                return suggestion;
-            },
-            inputValue: function (suggestion) {
-                if (suggestion) {
-                    return suggestion.split(':')[0];
-                }
-                return suggestion;
             }
-        }
-    });
+        });
 
-    updateAccessibleAutocompleteStyling(countrySelect);
+        updateAccessibleAutocompleteStyling(countrySelect);
+    }, 100)
 }
 


### PR DESCRIPTION
Wrap the `enhanceSelectElement` call in a `setTimeout` to ensure delayed execution. This change prevents initialization issues and ensures proper rendering of the accessible autocomplete component.