### PR TITLE
DAC6-3596 | Added new SignOutAction and related specs

### DIFF
--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -32,6 +32,7 @@ class Module extends AbstractModule {
     bind(classOf[DataInitializeAction]).to(classOf[DataInitializeActionImpl]).asEagerSingleton()
     // For session based storage instead of cred based, change to SessionIdentifierAction
     bind(classOf[IdentifierAction]).to(classOf[AuthenticatedIdentifierAction]).asEagerSingleton()
+    bind(classOf[SignOutAction]).to(classOf[AuthenticatedSignOutAction]).asEagerSingleton()
     bind(classOf[CheckForSubmissionAction]).to(classOf[CheckForSubmissionActionImpl]).asEagerSingleton()
     bind(classOf[Clock]).toInstance(Clock.systemDefaultZone.withZone(ZoneOffset.UTC))
     bind(classOf[CtUtrRetrievalAction]).to(classOf[CtUtrRetrievalActionImpl]).asEagerSingleton()

--- a/app/controllers/actions/SignOutAction.scala
+++ b/app/controllers/actions/SignOutAction.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import com.google.inject.Inject
+import config.FrontendAppConfig
+import controllers.routes
+import models.requests.IdentifierRequest
+import play.api.mvc.Results._
+import play.api.mvc._
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{affinityGroup, credentialRole}
+import uk.gov.hmrc.auth.core.retrieve.~
+import uk.gov.hmrc.http.{HeaderCarrier, UnauthorizedException}
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait SignOutAction extends ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest]
+
+class AuthenticatedSignOutAction @Inject() (
+  override val authConnector: AuthConnector,
+  config: FrontendAppConfig,
+  val parser: BodyParsers.Default
+)(implicit val executionContext: ExecutionContext)
+    extends SignOutAction
+    with AuthorisedFunctions {
+
+  val enrolmentKey: String = config.enrolmentKey
+
+  override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] = {
+
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+
+    authorised().retrieve(Retrievals.internalId and Retrievals.allEnrolments and affinityGroup and credentialRole) {
+      case Some(internalID) ~ enrolments ~ Some(affinityGroup) ~ _ => block(IdentifierRequest(request, internalID, affinityGroup, enrolments.enrolments))
+      case _                                                       => throw new UnauthorizedException("Unable to retrieve internal Id")
+    } recover {
+      case _: NoActiveSession =>
+        Redirect(config.loginUrl, Map("continue" -> Seq(config.loginContinueUrl)))
+      case _: AuthorisationException =>
+        Redirect(routes.UnauthorisedController.onPageLoad)
+    }
+  }
+
+}

--- a/app/controllers/auth/AuthController.scala
+++ b/app/controllers/auth/AuthController.scala
@@ -17,7 +17,7 @@
 package controllers.auth
 
 import config.FrontendAppConfig
-import controllers.actions.IdentifierAction
+import controllers.actions.SignOutAction
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import repositories.SessionRepository
@@ -30,12 +30,12 @@ class AuthController @Inject() (
   val controllerComponents: MessagesControllerComponents,
   config: FrontendAppConfig,
   sessionRepository: SessionRepository,
-  identify: IdentifierAction
+  identify: SignOutAction
 )(implicit ec: ExecutionContext)
     extends FrontendBaseController
     with I18nSupport {
 
-  def signOut(): Action[AnyContent] = identify().async {
+  def signOut(): Action[AnyContent] = identify.async {
     implicit request =>
       sessionRepository
         .clear(request.userId)
@@ -45,7 +45,7 @@ class AuthController @Inject() (
         }
   }
 
-  def signOutNoSurvey(): Action[AnyContent] = identify().async {
+  def signOutNoSurvey(): Action[AnyContent] = identify.async {
     implicit request =>
       sessionRepository
         .clear(request.userId)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -97,7 +97,7 @@ mongodb {
 urls {
   login         = "http://localhost:9949/auth-login-stub/gg-sign-in"
   loginContinue = "http://localhost:10030/register-for-crs-and-fatca"
-  signOut       = "http://localhost:9025/gg/sign-out"
+  signOut       = "http://localhost:9553/bas-gateway/sign-out-without-state"
   crsFatcaFIManagementFrontend = "http://localhost:10033/manage-your-crs-and-fatca-financial-institutions"
   addFinancialInstitution = "http://localhost:10033/manage-your-crs-and-fatca-financial-institutions/add"
   btaLogin = "https://www.gov.uk/guidance/sign-in-to-your-hmrc-business-tax-account"

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -68,6 +68,7 @@ trait SpecBase
 
   def onwardRoute: Call                                    = Call("GET", "/foo")
   final val mockDataRetrievalAction: DataRetrievalAction   = mock[DataRetrievalAction]
+  final val mockSignOutAction: SignOutAction               = mock[SignOutAction]
   final val mockSessionRepository: SessionRepository       = mock[SessionRepository]
   final val mockAddressLookupConnector                     = mock[AddressLookupConnector]
   final val mockCtUtrRetrievalAction: CtUtrRetrievalAction = mock[CtUtrRetrievalAction]
@@ -94,6 +95,7 @@ trait SpecBase
       .overrides(
         bind[DataRequiredAction].to[DataRequiredActionImpl],
         bind[IdentifierAction].toInstance(new FakeIdentifierAction(injectedParsers, affinityGroup)),
+        bind[SignOutAction].toInstance(new FakeSignOutAction(injectedParsers, affinityGroup)),
         bind[DataRetrievalAction].toInstance(mockDataRetrievalAction),
         bind[SessionRepository].toInstance(mockSessionRepository)
       )

--- a/test/controllers/actions/FakeSignOutAction.scala
+++ b/test/controllers/actions/FakeSignOutAction.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import models.requests.IdentifierRequest
+import play.api.mvc._
+import uk.gov.hmrc.auth.core.{AffinityGroup, Enrolment}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class FakeSignOutAction @Inject() (
+  bodyParsers: PlayBodyParsers,
+  affinityGroup: AffinityGroup
+) extends SignOutAction
+    with ActionBuilder[IdentifierRequest, AnyContent]
+    with ActionFunction[Request, IdentifierRequest] {
+
+  override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] = {
+    val fakeInternalId = "id"
+    val fakeEnrolments = Set.empty[Enrolment]
+
+    block(IdentifierRequest(request, fakeInternalId, affinityGroup, fakeEnrolments))
+  }
+
+  override def parser: BodyParser[AnyContent] = bodyParsers.default
+
+  override protected def executionContext: ExecutionContext =
+    scala.concurrent.ExecutionContext.Implicits.global
+
+}


### PR DESCRIPTION
Added new signout action that clears all session data (including fi management related data) when clicking signout from registration. 

Also amended signout links to now use appropriate bas-gateway service to signout and then take the user to relevant feedback survey URL. 