### PR TITLE
TECHDEBT: address flaky spec generators

### DIFF
--- a/test/pages/DoYouHaveUniqueTaxPayerReferencePageSpec.scala
+++ b/test/pages/DoYouHaveUniqueTaxPayerReferencePageSpec.scala
@@ -48,7 +48,7 @@ class DoYouHaveUniqueTaxPayerReferencePageSpec extends PageBehaviours {
 
   "cleanup" - {
     "if answer is false" in {
-      forAll(testParamGenerator) {
+      forAll(testParamGenerator.suchThat(_ != null)) {
         case (addressLookup, address, postcode, name, booleanField, nino, registrationInfo, dob) =>
           val ua = emptyUserAnswers
             .withPage(WhatIsYourUTRPage, UniqueTaxpayerReference("utr12345"))
@@ -69,7 +69,7 @@ class DoYouHaveUniqueTaxPayerReferencePageSpec extends PageBehaviours {
     }
 
     "if answer is true" in {
-      forAll(testParamGenerator) {
+      forAll(testParamGenerator.suchThat(_ != null)) {
         case (addressLookup, address, postcode, name, booleanField, nino, registrationInfo, dob) =>
           val ua = emptyUserAnswers
             .withPage(BusinessNameWithoutIDPage, "BusinessNameWithoutID")

--- a/test/pages/IndDoYouHaveNINumberPageSpec.scala
+++ b/test/pages/IndDoYouHaveNINumberPageSpec.scala
@@ -49,7 +49,7 @@ class IndDoYouHaveNINumberPageSpec extends PageBehaviours {
 
     "cleanup" - {
       "must remove individual without Id answers when true" in {
-        forAll(individualWithoutIdTestParamGenerator) {
+        forAll(individualWithoutIdTestParamGenerator.suchThat(_ != null)) {
           case (addressLookup, address, postcode, name, booleanField) =>
             val userAnswers = emptyUserAnswers
               .withPage(IndWhatIsYourNamePage, name)
@@ -79,7 +79,7 @@ class IndDoYouHaveNINumberPageSpec extends PageBehaviours {
       }
 
       "must remove individual with Id answers when false" in {
-        forAll(individualWithIdTestParamGenerator) {
+        forAll(individualWithIdTestParamGenerator.suchThat(_ != null)) {
           case (name, nino, registrationInfo) =>
             val userAnswers = emptyUserAnswers
               .withPage(IndWhatIsYourNINumberPage, nino)

--- a/test/pages/IsThisYourBusinessPageSpec.scala
+++ b/test/pages/IsThisYourBusinessPageSpec.scala
@@ -41,7 +41,7 @@ class IsThisYourBusinessPageSpec extends PageBehaviours {
   "cleanup" - {
     "must remove answers answers when Yes" in {
 
-      forAll(testParamGenerator) {
+      forAll(testParamGenerator.suchThat(_ != null)) {
         case (addressLookup, address, postcode, registrationInfo) =>
           val userAnswers = emptyUserAnswers
             .withPage(IndWhatIsYourPostcodePage, postcode)

--- a/test/pages/RegisteredAddressInUKPageSpec.scala
+++ b/test/pages/RegisteredAddressInUKPageSpec.scala
@@ -47,7 +47,7 @@ class RegisteredAddressInUKPageSpec extends PageBehaviours {
 
     "cleanup" - {
       "must remove business without Id answers when true" in {
-        forAll(businessWithoutIdTestParamGenerator) {
+        forAll(businessWithoutIdTestParamGenerator.suchThat(_ != null)) {
           case (addressLookup, address, postcode, name, booleanField, nino, date, stringField, registrationInfo) =>
             val userAnswers = emptyUserAnswers
               .withPage(DateOfBirthWithoutIdPage, LocalDate.now())

--- a/test/pages/ReporterTypePageSpec.scala
+++ b/test/pages/ReporterTypePageSpec.scala
@@ -169,9 +169,9 @@ class ReporterTypePageSpec extends PageBehaviours {
 
   def generateUserAnswers(cleanupType: ReporterType): UserAnswers = {
     val answers = cleanupType match {
-      case Individual => createUserAnswersForIndividualCleanup
-      case Sole       => createUserAnswersForSoleTraderCleanup
-      case _          => createUserAnswersForLimitedCompanyCleanup
+      case Individual => createUserAnswersForIndividualCleanup.suchThat(_ != null)
+      case Sole       => createUserAnswersForSoleTraderCleanup.suchThat(_ != null)
+      case _          => createUserAnswersForLimitedCompanyCleanup.suchThat(_ != null)
     }
     answers.sample match {
       case Some(value) => value


### PR DESCRIPTION
add a generator condition to disallow null/empty generated data to avoid occasional None.get's