### PR TITLE
DAC6-3546: Add EnrolmentResponse model

### DIFF
--- a/app/connectors/EnrolmentStoreProxyConnector.scala
+++ b/app/connectors/EnrolmentStoreProxyConnector.scala
@@ -70,7 +70,7 @@ class EnrolmentStoreProxyConnector @Inject() (val config: FrontendAppConfig, val
         }
     }
 
-  private def checkGroupEnrolments(groupIds: Seq[String])(implicit hc: HeaderCarrier, ec: ExecutionContext): EitherT[Future, ApiError, Boolean] = {
+  def checkGroupEnrolments(groupIds: Seq[String])(implicit hc: HeaderCarrier, ec: ExecutionContext): EitherT[Future, ApiError, Boolean] = {
     val groups = groupIds.toSet
     val calls: Set[EitherT[Future, ApiError, Boolean]] = groups.map {
       groupId =>

--- a/app/connectors/EnrolmentStoreProxyConnector.scala
+++ b/app/connectors/EnrolmentStoreProxyConnector.scala
@@ -19,11 +19,12 @@ package connectors
 import cats.data.EitherT
 import config.FrontendAppConfig
 import models.SubscriptionID
-import models.enrolment.GroupIds
+import models.enrolment.{EnrolmentResponse, GroupIds}
 import models.error.ApiError
 import models.error.ApiError.{EnrolmentExistsError, MalformedError}
 import play.api.Logging
 import play.api.http.Status.NO_CONTENT
+import play.api.libs.json.JsValue
 import uk.gov.hmrc.http.HttpErrorFunctions.is2xx
 import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -38,31 +39,57 @@ class EnrolmentStoreProxyConnector @Inject() (val config: FrontendAppConfig, val
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): EitherT[Future, ApiError, Unit] = {
-    val serviceEnrolmentPattern = s"HMRC-FATCA-ORG~FATCAID~${subscriptionID.value}"
-    val submissionUrl           = url"${config.enrolmentStoreProxyUrl}/enrolment-store/enrolments/$serviceEnrolmentPattern/groups"
+    val serviceEnrolmentPattern                             = s"HMRC-FATCA-ORG~FATCAID~${subscriptionID.value}"
+    val espUrl                                              = url"${config.enrolmentStoreProxyUrl}/enrolment-store/enrolments/$serviceEnrolmentPattern/groups"
+    val esResponse: EitherT[Future, ApiError, HttpResponse] = EitherT.right(http.get(espUrl).execute[HttpResponse])
     EitherT {
-      http
-        .get(submissionUrl)
-        .execute[HttpResponse]
-        .map {
-          case response if response.status == NO_CONTENT => Right(())
-          case response if is2xx(response.status) =>
-            response.json
-              .asOpt[GroupIds]
-              .map(
-                groupIds =>
-                  if (groupIds.principalGroupIds.nonEmpty) {
-                    Left(EnrolmentExistsError(groupIds))
-                  } else {
-                    Right(())
-                  }
-              )
-              .getOrElse(Right(()))
-          case response =>
-            logger.warn(s"Enrolment response not formed. ${response.status} response status")
-            Left(MalformedError(response.status))
+      esResponse.value.flatMap {
+        case Right(response) => response.status match {
+            case NO_CONTENT    => Future.successful(Right(()))
+            case s if is2xx(s) => parseAndAssertNoExisting(response.json).value
+            case other =>
+              logger.error(s"Enrolment Store Proxy error: ${response.status} - ${response.body}")
+              Future.successful(Left(MalformedError(other)))
+          }
+        case Left(error) =>
+          logger.error(s"Enrolment Store Proxy error: $error")
+          Future.successful(Left(error))
+      }
+    }
+  }
+
+  private def parseAndAssertNoExisting(json: JsValue)(implicit hc: HeaderCarrier, ec: ExecutionContext): EitherT[Future, ApiError, Unit] =
+    json.asOpt[GroupIds] match {
+      case None                                                 => EitherT.rightT(())
+      case Some(groupIds) if groupIds.principalGroupIds.isEmpty => EitherT.rightT(())
+      case Some(groupIds) => EitherT {
+          checkGroupEnrolments(groupIds.principalGroupIds).map {
+            case true =>
+              logger.warn(s"Enrolment already exists for groupIds: ${groupIds.principalGroupIds}")
+              Left(EnrolmentExistsError(groupIds))
+            case false => Right(())
+          }
         }
     }
+
+  private def checkGroupEnrolments(groupIds: Seq[String])(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Boolean] = {
+    val groups = groupIds.toSet
+    val calls: Set[Future[Boolean]] = groups.map {
+      groupId =>
+        val url = url"${config.enrolmentStoreProxyUrl}/enrolment-store/enrolments/$groupId/groups"
+        http
+          .get(url)
+          .execute[HttpResponse]
+          .map {
+            case response if is2xx(response.status) =>
+              response.json
+                .asOpt[EnrolmentResponse].exists(_.enrolments.nonEmpty)
+            case response =>
+              logger.warn(s"Enrolment response not formed. ${response.status} response status")
+              false
+          }
+    }
+    Future.foldLeft(calls)(false)(_ || _)
   }
 
 }

--- a/app/connectors/TaxEnrolmentsConnector.scala
+++ b/app/connectors/TaxEnrolmentsConnector.scala
@@ -58,6 +58,11 @@ class TaxEnrolmentsConnector @Inject() (
             logger.error(s"Service error when creating enrolment  ${responseMessage.status} : ${responseMessage.body}")
             Left(ServiceUnavailableError)
         }
+        .recover {
+          case e: Exception =>
+            logger.error(s"Service error when creating enrolment  ${e.getMessage}")
+            Left(ServiceUnavailableError)
+        }
     }
   }
 

--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -99,8 +99,11 @@ class CheckYourAnswersController @Inject() (
   }
 
   private def redirectToAlreadyRegistered(isNotOrg: Boolean) =
-    if (isNotOrg) Future.successful(Redirect(controllers.individual.routes.IndividualAlreadyRegisteredController.onPageLoad()))
-    else Future.successful(Redirect(controllers.routes.PreRegisteredController.onPageLoad()))
+    if (isNotOrg) {
+      Future.successful(Redirect(controllers.individual.routes.IndividualAlreadyRegisteredController.onPageLoad()))
+    } else {
+      Future.successful(Redirect(controllers.routes.PreRegisteredController.onPageLoad()))
+    }
 
   private def getSafeIdFromRegistration()(implicit request: DataRequest[AnyContent], hc: HeaderCarrier): Future[Either[ApiError, SafeId]] =
     request.userAnswers.get(RegistrationInfoPage) match {

--- a/app/controllers/actions/IdentifierAction.scala
+++ b/app/controllers/actions/IdentifierAction.scala
@@ -96,10 +96,10 @@ class AuthenticatedIdentifierActionWithRegime @Inject() (
         Future.successful(Redirect(routes.UnauthorisedStandardUserController.onPageLoad()))
       case Some(internalID) ~ enrolments ~ Some(affinityGroup) ~ _ ~ Some(group) if groupCheck =>
         checkGroup(group, affinityGroup) {
-          block(IdentifierRequest(request, internalID, affinityGroup, enrolments.enrolments))
+          block(IdentifierRequest(request, internalID, affinityGroup, enrolments.enrolments, group = Some(group)))
         }
-      case Some(internalID) ~ enrolments ~ Some(affinityGroup) ~ _ ~ None =>
-        block(IdentifierRequest(request, internalID, affinityGroup, enrolments.enrolments))
+      case Some(internalID) ~ enrolments ~ Some(affinityGroup) ~ _ ~ group =>
+        block(IdentifierRequest(request, internalID, affinityGroup, enrolments.enrolments, group = group))
       case _ => throw new UnauthorizedException("Unable to retrieve internal Id")
     } recover {
       case _: NoActiveSession =>

--- a/app/controllers/actions/IdentifierAction.scala
+++ b/app/controllers/actions/IdentifierAction.scala
@@ -18,6 +18,7 @@ package controllers.actions
 
 import com.google.inject.Inject
 import config.FrontendAppConfig
+import connectors.EnrolmentStoreProxyConnector
 import controllers.routes
 import models.requests.IdentifierRequest
 import play.api.Logging
@@ -25,7 +26,7 @@ import play.api.mvc.Results._
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{affinityGroup, credentialRole}
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{affinityGroup, credentialRole, groupIdentifier}
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.{HeaderCarrier, UnauthorizedException}
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
@@ -33,27 +34,32 @@ import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import scala.concurrent.{ExecutionContext, Future}
 
 trait IdentifierAction {
-  def apply(redirect: Boolean = true): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest]
+  def apply(redirect: Boolean = true, groupCheck: Boolean = true): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest]
 }
 
 class AuthenticatedIdentifierAction @Inject() (
   override val authConnector: AuthConnector,
+  val esConnector: EnrolmentStoreProxyConnector,
   config: FrontendAppConfig,
   val parser: BodyParsers.Default
 )(implicit val executionContext: ExecutionContext)
     extends IdentifierAction
     with AuthorisedFunctions {
 
-  override def apply(redirect: Boolean = true): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest] =
-    new AuthenticatedIdentifierActionWithRegime(authConnector, config, parser, redirect)
+  override def apply(redirect: Boolean = true,
+                     groupCheck: Boolean = true
+  ): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest] =
+    new AuthenticatedIdentifierActionWithRegime(authConnector, esConnector, config, parser, redirect, groupCheck)
 
 }
 
 class AuthenticatedIdentifierActionWithRegime @Inject() (
   override val authConnector: AuthConnector,
+  val esConnector: EnrolmentStoreProxyConnector,
   config: FrontendAppConfig,
   val parser: BodyParsers.Default,
-  val redirect: Boolean
+  val redirect: Boolean,
+  val groupCheck: Boolean
 )(implicit val executionContext: ExecutionContext)
     extends ActionBuilder[IdentifierRequest, AnyContent]
     with ActionFunction[Request, IdentifierRequest]
@@ -62,17 +68,39 @@ class AuthenticatedIdentifierActionWithRegime @Inject() (
 
   val enrolmentKey: String = config.enrolmentKey
 
+  private def checkGroup(groupId: String, affinityGroup: AffinityGroup)(block: => Future[Result])(implicit hc: HeaderCarrier): Future[Result] = {
+    val isOrg = affinityGroup == AffinityGroup.Organisation
+    esConnector.checkGroupEnrolments(Seq(groupId)).value flatMap {
+      case Right(true) =>
+        logger.info(s"User is already enrolled in the group: $groupId")
+        if (isOrg) {
+          Future.successful(Redirect(controllers.routes.PreRegisteredController.onPageLoad()))
+        } else {
+          Future.successful(Redirect(controllers.individual.routes.IndividualAlreadyRegisteredController.onPageLoad()))
+        }
+      case Right(false) => block
+      case _ =>
+        logger.warn(s"Unable to retrieve group enrolments for group: $groupId")
+        Future.successful(Redirect(routes.UnauthorisedController.onPageLoad))
+    }
+  }
+
   override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] = {
 
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
-    authorised().retrieve(Retrievals.internalId and Retrievals.allEnrolments and affinityGroup and credentialRole) {
-      case _ ~ enrolments ~ _ ~ _ if enrolments.enrolments.exists(_.key == enrolmentKey) && redirect =>
+    authorised().retrieve(Retrievals.internalId and Retrievals.allEnrolments and affinityGroup and credentialRole and groupIdentifier) {
+      case _ ~ enrolments ~ _ ~ _ ~ _ if enrolments.enrolments.exists(_.key == enrolmentKey) && redirect =>
         Future.successful(Redirect(config.crsFatcaFIManagementFrontendUrl))
-      case _ ~ _ ~ _ ~ Some(Assistant) =>
+      case _ ~ _ ~ _ ~ Some(Assistant) ~ _ =>
         Future.successful(Redirect(routes.UnauthorisedStandardUserController.onPageLoad()))
-      case Some(internalID) ~ enrolments ~ Some(affinityGroup) ~ _ => block(IdentifierRequest(request, internalID, affinityGroup, enrolments.enrolments))
-      case _                                                       => throw new UnauthorizedException("Unable to retrieve internal Id")
+      case Some(internalID) ~ enrolments ~ Some(affinityGroup) ~ _ ~ Some(group) if groupCheck =>
+        checkGroup(group, affinityGroup) {
+          block(IdentifierRequest(request, internalID, affinityGroup, enrolments.enrolments))
+        }
+      case Some(internalID) ~ enrolments ~ Some(affinityGroup) ~ _ ~ None =>
+        block(IdentifierRequest(request, internalID, affinityGroup, enrolments.enrolments))
+      case _ => throw new UnauthorizedException("Unable to retrieve internal Id")
     } recover {
       case _: NoActiveSession =>
         Redirect(config.loginUrl, Map("continue" -> Seq(config.loginContinueUrl)))

--- a/app/controllers/actions/StandardActionSets.scala
+++ b/app/controllers/actions/StandardActionSets.scala
@@ -55,8 +55,8 @@ class StandardActionSets @Inject() (identify: IdentifierAction,
   def identifiedUserWithInitializedData(): ActionBuilder[DataRequest, AnyContent] =
     identifiedUserWithEnrolmentCheck() andThen getData() andThen initializeData
 
-  def identifiedUserWithData(): ActionBuilder[DataRequest, AnyContent] =
-    identifiedUserWithEnrolmentCheck() andThen getData() andThen requireData
+  def identifiedUserWithData(groupCheck: Boolean = true): ActionBuilder[DataRequest, AnyContent] =
+    identify(groupCheck = groupCheck) andThen getData() andThen requireData
 
   def identifiedUserWithDependantAnswer[T](answer: Gettable[T])(implicit reads: Reads[T]): ActionBuilder[DataRequest, AnyContent] =
     identifiedUserWithData() andThen dependantAnswer(answer)

--- a/app/controllers/individual/IndividualAlreadyRegisteredController.scala
+++ b/app/controllers/individual/IndividualAlreadyRegisteredController.scala
@@ -16,7 +16,6 @@
 
 package controllers.individual
 
-import controllers.actions._
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
@@ -26,13 +25,12 @@ import javax.inject.Inject
 
 class IndividualAlreadyRegisteredController @Inject() (
   override val messagesApi: MessagesApi,
-  standardActionSets: StandardActionSets,
   val controllerComponents: MessagesControllerComponents,
   view: IndividualAlreadyRegisteredView
 ) extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = standardActionSets.identifiedUserWithData() {
+  def onPageLoad: Action[AnyContent] = Action {
     implicit request =>
       Ok(view())
   }

--- a/app/controllers/organisation/PreRegisteredController.scala
+++ b/app/controllers/organisation/PreRegisteredController.scala
@@ -17,7 +17,6 @@
 package controllers
 
 import config.FrontendAppConfig
-import controllers.actions._
 
 import javax.inject.Inject
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -27,14 +26,13 @@ import views.html.organisation.PreRegisteredView
 
 class PreRegisteredController @Inject() (
   override val messagesApi: MessagesApi,
-  standardActionSets: StandardActionSets,
   val controllerComponents: MessagesControllerComponents,
   view: PreRegisteredView,
   frontendAppConfig: FrontendAppConfig
 ) extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad(): Action[AnyContent] = standardActionSets.identifiedUserWithData() {
+  def onPageLoad(): Action[AnyContent] = Action {
     implicit request =>
       Ok(view(frontendAppConfig.emailEnquiries))
   }

--- a/app/models/enrolment/EnrolmentResponse.scala
+++ b/app/models/enrolment/EnrolmentResponse.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.enrolment
+
+import play.api.libs.json.{Json, OFormat}
+
+case class EnrolmentResponse(startRecord: Int, totalRecords: Int, enrolments: Seq[Enrolment])
+
+object EnrolmentResponse {
+  implicit val format: OFormat[EnrolmentResponse] = Json.format[EnrolmentResponse]
+}
+
+case class Enrolment(service: String, state: String, identifiers: Seq[Identifier])
+
+object Enrolment {
+  implicit val format: OFormat[Enrolment] = Json.format[Enrolment]
+}

--- a/app/models/requests/IdentifierRequest.scala
+++ b/app/models/requests/IdentifierRequest.scala
@@ -25,5 +25,6 @@ case class IdentifierRequest[A](
   userId: String,
   affinityGroup: AffinityGroup,
   enrolments: Set[Enrolment] = Set.empty,
-  utr: Option[UniqueTaxpayerReference] = None
+  utr: Option[UniqueTaxpayerReference] = None,
+  group: Option[String] = None
 ) extends WrappedRequest[A](request)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,7 +7,7 @@ object AppDependencies {
 
   val compile = Seq[ModuleID](
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "12.0.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"            % "12.1.0",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30" % "3.3.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"            % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"                    % hmrcMongoVersion,

--- a/test/connectors/EnrolmentStoreProxyConnectorSpec.scala
+++ b/test/connectors/EnrolmentStoreProxyConnectorSpec.scala
@@ -42,8 +42,10 @@ class EnrolmentStoreProxyConnectorSpec extends SpecBase with WireMockServerHandl
 
   lazy val connector: EnrolmentStoreProxyConnector = application.injector.instanceOf[EnrolmentStoreProxyConnector]
   val enrolmentStoreProxyUrl                       = "/enrolment-store-proxy/enrolment-store/enrolments"
-  val enrolmentStoreProxy200Url                    = "/enrolment-store-proxy/enrolment-store/enrolments/HMRC-FATCA-ORG~FATCAID~xxx200/groups"
-  val enrolmentStoreProxy204Url                    = "/enrolment-store-proxy/enrolment-store/enrolments/HMRC-FATCA-ORG~FATCAID~xxx204/groups"
+  val enrolmentStoreProxy1200Url                   = "/enrolment-store-proxy/enrolment-store/enrolments/HMRC-FATCA-ORG~FATCAID~xxx200/groups"
+  val enrolmentStoreProxy1204Url                   = "/enrolment-store-proxy/enrolment-store/enrolments/HMRC-FATCA-ORG~FATCAID~xxx204/groups"
+  val enrolmentStoreProxy3200Url001                = "/enrolment-store-proxy/enrolment-store/groups/ABCEDEFGI1234567/enrolments?service=HMRC-FATCA-ORG"
+  val enrolmentStoreProxy3200Url002                = "/enrolment-store-proxy/enrolment-store/groups/ABCEDEFGI1234568/enrolments?service=HMRC-FATCA-ORG"
 
   val enrolmentStoreProxyResponseJson: String =
     """{
@@ -57,6 +59,39 @@ class EnrolmentStoreProxyConnectorSpec extends SpecBase with WireMockServerHandl
       |  ]
       |}""".stripMargin
 
+  val es3EmptyResponseJson: String =
+    """
+      |{
+      |    "startRecord": 1,
+      |    "totalRecords": 2,
+      |    "enrolments": []
+      |}
+      |""".stripMargin
+
+  val es3NonEmptyResponseJson: String =
+    """
+      |{
+      |  "startRecord": 1,
+      |  "totalRecords": 2,
+      |  "enrolments": [
+      |    {
+      |      "service": "HMRC-FATCA-ORG",
+      |      "state": "Activated",
+      |      "friendlyName": "My First Client's SA Enrolment",
+      |      "enrolmentDate": "2018-10-05T14:48:00.000Z",
+      |      "failedActivationCount": 1,
+      |      "activationDate": "2018-10-13T17:36:00.000Z",
+      |      "identifiers": [
+      |        {
+      |          "key": "UTR",
+      |          "value": "1234567890"
+      |        }
+      |      ]
+      |    }
+      |  ]
+      |}
+      |""".stripMargin
+
   val enrolmentStoreProxyResponseNoPrincipalIdJson: String =
     """{
       |  "principalGroupIds": []
@@ -65,17 +100,28 @@ class EnrolmentStoreProxyConnectorSpec extends SpecBase with WireMockServerHandl
   "EnrolmentStoreProxyConnector" - {
     "when calling enrolmentStatus" - {
 
-      "return 200 and a enrolmentStatus response when already enrolment exists" in {
+      "return 200 and a enrolmentStatus response when already enrolments exist for matching groups" in {
         val subscriptionID = SubscriptionID("xxx200")
         val groupIds       = Json.parse(enrolmentStoreProxyResponseJson).as[GroupIds]
-        stubResponse(enrolmentStoreProxy200Url, OK, enrolmentStoreProxyResponseJson)
+        stubResponse(enrolmentStoreProxy3200Url001, OK, es3NonEmptyResponseJson)
+        stubResponse(enrolmentStoreProxy3200Url002, OK, es3NonEmptyResponseJson)
+        stubResponse(enrolmentStoreProxy1200Url, OK, enrolmentStoreProxyResponseJson)
         val result = connector.enrolmentStatus(subscriptionID)
         result.value.futureValue mustBe Left(EnrolmentExistsError(groupIds))
       }
 
+      "return 200 and a enrolmentStatus response when enrolments do not exist for matching groups" in {
+        val subscriptionID = SubscriptionID("xxx200")
+        stubResponse(enrolmentStoreProxy3200Url001, OK, es3EmptyResponseJson)
+        stubResponse(enrolmentStoreProxy3200Url002, OK, es3EmptyResponseJson)
+        stubResponse(enrolmentStoreProxy1200Url, OK, enrolmentStoreProxyResponseJson)
+        val result = connector.enrolmentStatus(subscriptionID)
+        result.value.futureValue mustBe Right(())
+      }
+
       "return 204 and a enrolmentStatus response when no enrolment exists" in {
         val subscriptionID = SubscriptionID("xxx204")
-        stubResponse(enrolmentStoreProxy204Url, NO_CONTENT, "")
+        stubResponse(enrolmentStoreProxy1204Url, NO_CONTENT, "")
 
         val result = connector.enrolmentStatus(subscriptionID)
         result.value.futureValue mustBe Right(())
@@ -83,14 +129,14 @@ class EnrolmentStoreProxyConnectorSpec extends SpecBase with WireMockServerHandl
 
       "return 204 enrolmentStatus response when principalGroupId is empty seq" in {
         val subscriptionID = SubscriptionID("xxx204")
-        stubResponse(enrolmentStoreProxy204Url, OK, enrolmentStoreProxyResponseNoPrincipalIdJson)
+        stubResponse(enrolmentStoreProxy1204Url, OK, enrolmentStoreProxyResponseNoPrincipalIdJson)
         val result = connector.enrolmentStatus(subscriptionID)
         result.value.futureValue mustBe Right(())
       }
 
       "return 404 and a enrolmentStatus response when invalid or malfromed URL" in {
         val subscriptionID = SubscriptionID("xxx404")
-        stubResponse(enrolmentStoreProxy204Url, NOT_FOUND, "")
+        stubResponse(enrolmentStoreProxy1204Url, NOT_FOUND, "")
 
         val result = connector.enrolmentStatus(subscriptionID)
         result.value.futureValue mustBe Left(MalformedError(NOT_FOUND))

--- a/test/controllers/RegistrationConfirmationControllerSpec.scala
+++ b/test/controllers/RegistrationConfirmationControllerSpec.scala
@@ -27,7 +27,7 @@ import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AffinityGroup
-import views.html.{PageUnavailableView, RegistrationConfirmationView, ThereIsAProblemView}
+import views.html.{PageUnavailableView, RegistrationConfirmationView}
 
 import scala.concurrent.Future
 

--- a/test/controllers/actions/FakeIdentifierAction.scala
+++ b/test/controllers/actions/FakeIdentifierAction.scala
@@ -37,6 +37,8 @@ class FakeIdentifierAction @Inject() (bodyParsers: PlayBodyParsers, affinityGrou
   override protected def executionContext: ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global
 
-  override def apply(redirect: Boolean = true): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest] = this
+  override def apply(redirect: Boolean = true,
+                     groupCheck: Boolean = true
+  ): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest] = this
 
 }


### PR DESCRIPTION
Introduce the `EnrolmentResponse` model to handle enrolment-related API responses. Refactor the logic in `EnrolmentStoreProxyConnector` to enhance error handling and incorporate checks for existing enrolments using the new model.