### PR TITLE
DAC6-3546: Remove group enrolment checks

### DIFF
--- a/app/connectors/EnrolmentStoreProxyConnector.scala
+++ b/app/connectors/EnrolmentStoreProxyConnector.scala
@@ -19,12 +19,11 @@ package connectors
 import cats.data.EitherT
 import config.FrontendAppConfig
 import models.SubscriptionID
-import models.enrolment.{EnrolmentResponse, GroupIds}
+import models.enrolment.GroupIds
 import models.error.ApiError
 import models.error.ApiError.{EnrolmentExistsError, MalformedError}
 import play.api.Logging
 import play.api.http.Status.NO_CONTENT
-import play.api.libs.json.JsValue
 import uk.gov.hmrc.http.HttpErrorFunctions.is2xx
 import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
 import uk.gov.hmrc.http.client.HttpClientV2
@@ -39,60 +38,30 @@ class EnrolmentStoreProxyConnector @Inject() (val config: FrontendAppConfig, val
     hc: HeaderCarrier,
     ec: ExecutionContext
   ): EitherT[Future, ApiError, Unit] = {
-    val serviceEnrolmentPattern                             = s"HMRC-FATCA-ORG~FATCAID~${subscriptionID.value}"
-    val espUrl                                              = url"${config.enrolmentStoreProxyUrl}/enrolment-store/enrolments/$serviceEnrolmentPattern/groups"
-    val esResponse: EitherT[Future, ApiError, HttpResponse] = EitherT.right(http.get(espUrl).execute[HttpResponse])
+    val serviceEnrolmentPattern = s"HMRC-FATCA-ORG~FATCAID~${subscriptionID.value}"
+    val submissionUrl           = url"${config.enrolmentStoreProxyUrl}/enrolment-store/enrolments/$serviceEnrolmentPattern/groups"
     EitherT {
-      esResponse.value.flatMap {
-        case Right(response) => response.status match {
-            case NO_CONTENT    => Future.successful(Right(()))
-            case s if is2xx(s) => parseAndAssertNoExisting(response.json).value
-            case other =>
-              logger.error(s"ES1: Enrolment Store Proxy error: ${response.status} - ${response.body}")
-              Future.successful(Left(MalformedError(other)))
-          }
-        case Left(error) =>
-          logger.error(s"ES1: Enrolment Store Proxy error: $error")
-          Future.successful(Left(error))
-      }
-    }
-  }
-
-  private def parseAndAssertNoExisting(json: JsValue)(implicit hc: HeaderCarrier, ec: ExecutionContext): EitherT[Future, ApiError, Unit] =
-    json.asOpt[GroupIds] match {
-      case None                                                 => EitherT.rightT(())
-      case Some(groupIds) if groupIds.principalGroupIds.isEmpty => EitherT.rightT(())
-      case Some(groupIds) => checkGroupEnrolments(groupIds.principalGroupIds).flatMap {
-          case true =>
-            logger.warn(s"Enrolment already exists for groupIds: ${groupIds.principalGroupIds}")
-            EitherT.leftT(EnrolmentExistsError(groupIds))
-          case false => EitherT.rightT(())
+      http
+        .get(submissionUrl)
+        .execute[HttpResponse]
+        .map {
+          case response if response.status == NO_CONTENT => Right(())
+          case response if is2xx(response.status) =>
+            response.json
+              .asOpt[GroupIds]
+              .map(
+                groupIds =>
+                  if (groupIds.principalGroupIds.nonEmpty) {
+                    Left(EnrolmentExistsError(groupIds))
+                  } else {
+                    Right(())
+                  }
+              )
+              .getOrElse(Right(()))
+          case response =>
+            logger.warn(s"Enrolment response not formed. ${response.status} response status")
+            Left(MalformedError(response.status))
         }
-    }
-
-  def checkGroupEnrolments(groupIds: Seq[String])(implicit hc: HeaderCarrier, ec: ExecutionContext): EitherT[Future, ApiError, Boolean] = {
-    val groups = groupIds.toSet
-    val calls: Set[EitherT[Future, ApiError, Boolean]] = groups.map {
-      groupId =>
-        val url = url"${config.enrolmentStoreProxyUrl}/enrolment-store/groups/$groupId/enrolments?service=${config.enrolmentKey}"
-        val f = http
-          .get(url)
-          .execute[HttpResponse]
-          .map {
-            case response if is2xx(response.status) =>
-              val hasEnrolment = response.json.asOpt[EnrolmentResponse].exists(_.enrolments.nonEmpty)
-              Right(hasEnrolment)
-            case response =>
-              Left(MalformedError(response.status))
-          }
-        EitherT(f)
-    }
-    calls.foldLeft(EitherT.rightT[Future, ApiError](false)) {
-      (accEt, callEt) =>
-        for {
-          acc  <- accEt
-          call <- callEt
-        } yield acc || call
     }
   }
 

--- a/app/connectors/TaxEnrolmentsConnector.scala
+++ b/app/connectors/TaxEnrolmentsConnector.scala
@@ -58,11 +58,6 @@ class TaxEnrolmentsConnector @Inject() (
             logger.error(s"Service error when creating enrolment  ${responseMessage.status} : ${responseMessage.body}")
             Left(ServiceUnavailableError)
         }
-        .recover {
-          case e: Exception =>
-            logger.error(s"Service error when creating enrolment  ${e.getMessage}")
-            Left(ServiceUnavailableError)
-        }
     }
   }
 

--- a/app/connectors/TaxEnrolmentsConnector.scala
+++ b/app/connectors/TaxEnrolmentsConnector.scala
@@ -58,6 +58,11 @@ class TaxEnrolmentsConnector @Inject() (
             logger.error(s"Service error when creating enrolment  ${responseMessage.status} : ${responseMessage.body}")
             Left(ServiceUnavailableError)
         }
+        .recover {
+          case e: Exception =>
+            logger.error(s"Service error when creating enrolment  ${e.getMessage}")
+            Left(ServiceUnavailableError)
+        }
     }
   }
 

--- a/app/controllers/actions/IdentifierAction.scala
+++ b/app/controllers/actions/IdentifierAction.scala
@@ -18,7 +18,6 @@ package controllers.actions
 
 import com.google.inject.Inject
 import config.FrontendAppConfig
-import connectors.EnrolmentStoreProxyConnector
 import controllers.routes
 import models.requests.IdentifierRequest
 import play.api.Logging
@@ -26,7 +25,7 @@ import play.api.mvc.Results._
 import play.api.mvc._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals
-import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{affinityGroup, credentialRole, groupIdentifier}
+import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals.{affinityGroup, credentialRole}
 import uk.gov.hmrc.auth.core.retrieve.~
 import uk.gov.hmrc.http.{HeaderCarrier, UnauthorizedException}
 import uk.gov.hmrc.play.http.HeaderCarrierConverter
@@ -34,32 +33,27 @@ import uk.gov.hmrc.play.http.HeaderCarrierConverter
 import scala.concurrent.{ExecutionContext, Future}
 
 trait IdentifierAction {
-  def apply(redirect: Boolean = true, groupCheck: Boolean = true): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest]
+  def apply(redirect: Boolean = true): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest]
 }
 
 class AuthenticatedIdentifierAction @Inject() (
   override val authConnector: AuthConnector,
-  val esConnector: EnrolmentStoreProxyConnector,
   config: FrontendAppConfig,
   val parser: BodyParsers.Default
 )(implicit val executionContext: ExecutionContext)
     extends IdentifierAction
     with AuthorisedFunctions {
 
-  override def apply(redirect: Boolean = true,
-                     groupCheck: Boolean = true
-  ): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest] =
-    new AuthenticatedIdentifierActionWithRegime(authConnector, esConnector, config, parser, redirect, groupCheck)
+  override def apply(redirect: Boolean = true): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest] =
+    new AuthenticatedIdentifierActionWithRegime(authConnector, config, parser, redirect)
 
 }
 
 class AuthenticatedIdentifierActionWithRegime @Inject() (
   override val authConnector: AuthConnector,
-  val esConnector: EnrolmentStoreProxyConnector,
   config: FrontendAppConfig,
   val parser: BodyParsers.Default,
-  val redirect: Boolean,
-  val groupCheck: Boolean
+  val redirect: Boolean
 )(implicit val executionContext: ExecutionContext)
     extends ActionBuilder[IdentifierRequest, AnyContent]
     with ActionFunction[Request, IdentifierRequest]
@@ -68,39 +62,17 @@ class AuthenticatedIdentifierActionWithRegime @Inject() (
 
   val enrolmentKey: String = config.enrolmentKey
 
-  private def checkGroup(groupId: String, affinityGroup: AffinityGroup)(block: => Future[Result])(implicit hc: HeaderCarrier): Future[Result] = {
-    val isOrg = affinityGroup == AffinityGroup.Organisation
-    esConnector.checkGroupEnrolments(Seq(groupId)).value flatMap {
-      case Right(true) =>
-        logger.info(s"User is already enrolled in the group: $groupId")
-        if (isOrg) {
-          Future.successful(Redirect(controllers.routes.PreRegisteredController.onPageLoad()))
-        } else {
-          Future.successful(Redirect(controllers.individual.routes.IndividualAlreadyRegisteredController.onPageLoad()))
-        }
-      case Right(false) => block
-      case _ =>
-        logger.warn(s"Unable to retrieve group enrolments for group: $groupId")
-        Future.successful(Redirect(routes.UnauthorisedController.onPageLoad))
-    }
-  }
-
   override def invokeBlock[A](request: Request[A], block: IdentifierRequest[A] => Future[Result]): Future[Result] = {
 
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
-    authorised().retrieve(Retrievals.internalId and Retrievals.allEnrolments and affinityGroup and credentialRole and groupIdentifier) {
-      case _ ~ enrolments ~ _ ~ _ ~ _ if enrolments.enrolments.exists(_.key == enrolmentKey) && redirect =>
+    authorised().retrieve(Retrievals.internalId and Retrievals.allEnrolments and affinityGroup and credentialRole) {
+      case _ ~ enrolments ~ _ ~ _ if enrolments.enrolments.exists(_.key == enrolmentKey) && redirect =>
         Future.successful(Redirect(config.crsFatcaFIManagementFrontendUrl))
-      case _ ~ _ ~ _ ~ Some(Assistant) ~ _ =>
+      case _ ~ _ ~ _ ~ Some(Assistant) =>
         Future.successful(Redirect(routes.UnauthorisedStandardUserController.onPageLoad()))
-      case Some(internalID) ~ enrolments ~ Some(affinityGroup) ~ _ ~ Some(group) if groupCheck =>
-        checkGroup(group, affinityGroup) {
-          block(IdentifierRequest(request, internalID, affinityGroup, enrolments.enrolments, group = Some(group)))
-        }
-      case Some(internalID) ~ enrolments ~ Some(affinityGroup) ~ _ ~ group =>
-        block(IdentifierRequest(request, internalID, affinityGroup, enrolments.enrolments, group = group))
-      case _ => throw new UnauthorizedException("Unable to retrieve internal Id")
+      case Some(internalID) ~ enrolments ~ Some(affinityGroup) ~ _ => block(IdentifierRequest(request, internalID, affinityGroup, enrolments.enrolments))
+      case _                                                       => throw new UnauthorizedException("Unable to retrieve internal Id")
     } recover {
       case _: NoActiveSession =>
         Redirect(config.loginUrl, Map("continue" -> Seq(config.loginContinueUrl)))

--- a/app/controllers/actions/StandardActionSets.scala
+++ b/app/controllers/actions/StandardActionSets.scala
@@ -55,8 +55,8 @@ class StandardActionSets @Inject() (identify: IdentifierAction,
   def identifiedUserWithInitializedData(): ActionBuilder[DataRequest, AnyContent] =
     identifiedUserWithEnrolmentCheck() andThen getData() andThen initializeData
 
-  def identifiedUserWithData(groupCheck: Boolean = true): ActionBuilder[DataRequest, AnyContent] =
-    identify(groupCheck = groupCheck) andThen getData() andThen requireData
+  def identifiedUserWithData(): ActionBuilder[DataRequest, AnyContent] =
+    identifiedUserWithEnrolmentCheck() andThen getData() andThen requireData
 
   def identifiedUserWithDependantAnswer[T](answer: Gettable[T])(implicit reads: Reads[T]): ActionBuilder[DataRequest, AnyContent] =
     identifiedUserWithData() andThen dependantAnswer(answer)

--- a/app/controllers/individual/IndividualAlreadyRegisteredController.scala
+++ b/app/controllers/individual/IndividualAlreadyRegisteredController.scala
@@ -16,6 +16,7 @@
 
 package controllers.individual
 
+import controllers.actions._
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
@@ -25,12 +26,13 @@ import javax.inject.Inject
 
 class IndividualAlreadyRegisteredController @Inject() (
   override val messagesApi: MessagesApi,
+  standardActionSets: StandardActionSets,
   val controllerComponents: MessagesControllerComponents,
   view: IndividualAlreadyRegisteredView
 ) extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = Action {
+  def onPageLoad: Action[AnyContent] = standardActionSets.identifiedUserWithData() {
     implicit request =>
       Ok(view())
   }

--- a/app/controllers/organisation/PreRegisteredController.scala
+++ b/app/controllers/organisation/PreRegisteredController.scala
@@ -17,6 +17,7 @@
 package controllers
 
 import config.FrontendAppConfig
+import controllers.actions._
 
 import javax.inject.Inject
 import play.api.i18n.{I18nSupport, MessagesApi}
@@ -26,13 +27,14 @@ import views.html.organisation.PreRegisteredView
 
 class PreRegisteredController @Inject() (
   override val messagesApi: MessagesApi,
+  standardActionSets: StandardActionSets,
   val controllerComponents: MessagesControllerComponents,
   view: PreRegisteredView,
   frontendAppConfig: FrontendAppConfig
 ) extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad(): Action[AnyContent] = Action {
+  def onPageLoad(): Action[AnyContent] = standardActionSets.identifiedUserWithData() {
     implicit request =>
       Ok(view(frontendAppConfig.emailEnquiries))
   }

--- a/app/models/requests/IdentifierRequest.scala
+++ b/app/models/requests/IdentifierRequest.scala
@@ -25,6 +25,5 @@ case class IdentifierRequest[A](
   userId: String,
   affinityGroup: AffinityGroup,
   enrolments: Set[Enrolment] = Set.empty,
-  utr: Option[UniqueTaxpayerReference] = None,
-  group: Option[String] = None
+  utr: Option[UniqueTaxpayerReference] = None
 ) extends WrappedRequest[A](request)

--- a/test/controllers/RegistrationConfirmationControllerSpec.scala
+++ b/test/controllers/RegistrationConfirmationControllerSpec.scala
@@ -27,7 +27,7 @@ import play.api.libs.json.Json
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core.AffinityGroup
-import views.html.{PageUnavailableView, RegistrationConfirmationView}
+import views.html.{PageUnavailableView, RegistrationConfirmationView, ThereIsAProblemView}
 
 import scala.concurrent.Future
 

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -17,30 +17,21 @@
 package controllers.actions
 
 import base.SpecBase
-import cats.data.EitherT
 import com.google.inject.Inject
 import config.FrontendAppConfig
-import connectors.EnrolmentStoreProxyConnector
 import controllers.routes
-import models.error.ApiError
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
 import play.api.mvc.{BodyParsers, Results}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.authorise.Predicate
-import uk.gov.hmrc.auth.core.retrieve.{~, Retrieval}
-import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
+import uk.gov.hmrc.auth.core.retrieve.Retrieval
 import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class AuthActionSpec extends SpecBase {
-
-  val groupId    = "ABC1234567"
-  val enrolments = Enrolments(Set.empty)
 
   class Harness(authAction: IdentifierAction) {
 
@@ -56,15 +47,13 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to log in " in {
 
-        val mockEsConnector = mock[EnrolmentStoreProxyConnector]
-
         val application = applicationBuilder(userAnswers = None).build()
 
         running(application) {
           val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
           val appConfig   = application.injector.instanceOf[FrontendAppConfig]
 
-          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new MissingBearerToken), mockEsConnector, appConfig, bodyParsers)
+          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new MissingBearerToken), appConfig, bodyParsers)
           val controller = new Harness(authAction)
           val result     = controller.onPageLoad()(FakeRequest())
 
@@ -78,14 +67,13 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to log in " in {
 
-        val application     = applicationBuilder(userAnswers = None).build()
-        val mockEsConnector = mock[EnrolmentStoreProxyConnector]
+        val application = applicationBuilder(userAnswers = None).build()
 
         running(application) {
           val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
           val appConfig   = application.injector.instanceOf[FrontendAppConfig]
 
-          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new BearerTokenExpired), mockEsConnector, appConfig, bodyParsers)
+          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new BearerTokenExpired), appConfig, bodyParsers)
           val controller = new Harness(authAction)
           val result     = controller.onPageLoad()(FakeRequest())
 
@@ -99,14 +87,13 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to the unauthorised page" in {
 
-        val application     = applicationBuilder(userAnswers = None).build()
-        val mockEsConnector = mock[EnrolmentStoreProxyConnector]
+        val application = applicationBuilder(userAnswers = None).build()
 
         running(application) {
           val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
           val appConfig   = application.injector.instanceOf[FrontendAppConfig]
 
-          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new InsufficientEnrolments), mockEsConnector, appConfig, bodyParsers)
+          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new InsufficientEnrolments), appConfig, bodyParsers)
           val controller = new Harness(authAction)
           val result     = controller.onPageLoad()(FakeRequest())
 
@@ -120,15 +107,13 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to the unauthorised page" in {
 
-        val application     = applicationBuilder(userAnswers = None).build()
-        val mockEsConnector = mock[EnrolmentStoreProxyConnector]
+        val application = applicationBuilder(userAnswers = None).build()
 
         running(application) {
           val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
           val appConfig   = application.injector.instanceOf[FrontendAppConfig]
 
-          val authAction =
-            new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new InsufficientConfidenceLevel), mockEsConnector, appConfig, bodyParsers)
+          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new InsufficientConfidenceLevel), appConfig, bodyParsers)
           val controller = new Harness(authAction)
           val result     = controller.onPageLoad()(FakeRequest())
 
@@ -142,14 +127,13 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to the unauthorised page" in {
 
-        val application     = applicationBuilder(userAnswers = None).build()
-        val mockEsConnector = mock[EnrolmentStoreProxyConnector]
+        val application = applicationBuilder(userAnswers = None).build()
 
         running(application) {
           val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
           val appConfig   = application.injector.instanceOf[FrontendAppConfig]
 
-          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedAuthProvider), mockEsConnector, appConfig, bodyParsers)
+          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedAuthProvider), appConfig, bodyParsers)
           val controller = new Harness(authAction)
           val result     = controller.onPageLoad()(FakeRequest())
 
@@ -163,15 +147,13 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to the unauthorised page" in {
 
-        val application     = applicationBuilder(userAnswers = None).build()
-        val mockEsConnector = mock[EnrolmentStoreProxyConnector]
+        val application = applicationBuilder(userAnswers = None).build()
 
         running(application) {
           val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
           val appConfig   = application.injector.instanceOf[FrontendAppConfig]
 
-          val authAction =
-            new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedAffinityGroup), mockEsConnector, appConfig, bodyParsers)
+          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedAffinityGroup), appConfig, bodyParsers)
           val controller = new Harness(authAction)
           val result     = controller.onPageLoad()(FakeRequest())
 
@@ -185,53 +167,18 @@ class AuthActionSpec extends SpecBase {
 
       "must redirect the user to the unauthorised page" in {
 
-        val application     = applicationBuilder(userAnswers = None).build()
-        val mockEsConnector = mock[EnrolmentStoreProxyConnector]
+        val application = applicationBuilder(userAnswers = None).build()
 
         running(application) {
           val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
           val appConfig   = application.injector.instanceOf[FrontendAppConfig]
 
-          val authAction =
-            new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedCredentialRole), mockEsConnector, appConfig, bodyParsers)
+          val authAction = new AuthenticatedIdentifierAction(new FakeFailingAuthConnector(new UnsupportedCredentialRole), appConfig, bodyParsers)
           val controller = new Harness(authAction)
           val result     = controller.onPageLoad()(FakeRequest())
 
           status(result) mustBe SEE_OTHER
           redirectLocation(result) mustBe Some(routes.UnauthorisedController.onPageLoad.url)
-        }
-      }
-    }
-
-    "the user has group-id already enrolled" - {
-
-      "must redirect the user to the already registered when group already enrolled" in {
-
-        val application     = applicationBuilder(userAnswers = None).build()
-        val mockEsConnector = mock[EnrolmentStoreProxyConnector]
-        val authConnector   = mock[AuthConnector]
-
-        when(authConnector.authorise(
-          any(),
-          any[Retrieval[Option[String] ~ Enrolments ~ Option[AffinityGroup] ~ Option[CredentialRole] ~ Option[String]]]()
-        )(any(), any()))
-          .thenReturn(
-            Future.successful(Some(groupId) and enrolments and Some(AffinityGroup.Organisation) and Some(User) and Some(groupId))
-          )
-
-        when(mockEsConnector.checkGroupEnrolments(any())(any(), any())).thenReturn(EitherT.rightT[Future, ApiError](true))
-
-        running(application) {
-          val bodyParsers = application.injector.instanceOf[BodyParsers.Default]
-          val appConfig   = application.injector.instanceOf[FrontendAppConfig]
-
-          val authAction =
-            new AuthenticatedIdentifierAction(authConnector, mockEsConnector, appConfig, bodyParsers)
-          val controller = new Harness(authAction)
-          val result     = controller.onPageLoad()(FakeRequest())
-
-          status(result) mustBe SEE_OTHER
-          redirectLocation(result) mustBe Some(controllers.routes.PreRegisteredController.onPageLoad.url)
         }
       }
     }

--- a/test/controllers/actions/FakeIdentifierAction.scala
+++ b/test/controllers/actions/FakeIdentifierAction.scala
@@ -37,8 +37,6 @@ class FakeIdentifierAction @Inject() (bodyParsers: PlayBodyParsers, affinityGrou
   override protected def executionContext: ExecutionContext =
     scala.concurrent.ExecutionContext.Implicits.global
 
-  override def apply(redirect: Boolean = true,
-                     groupCheck: Boolean = true
-  ): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest] = this
+  override def apply(redirect: Boolean = true): ActionBuilder[IdentifierRequest, AnyContent] with ActionFunction[Request, IdentifierRequest] = this
 
 }


### PR DESCRIPTION
Removed logic and dependencies related to group enrolment checks, including unused connector methods, parameters, and tests. This simplifies the codebase and reduces unnecessary complexity.