### PR TITLE
DAC6-3787: Refactor trading name logic

### DIFF
--- a/app/models/subscription/request/CreateSubscriptionRequest.scala
+++ b/app/models/subscription/request/CreateSubscriptionRequest.scala
@@ -16,7 +16,7 @@
 
 package models.subscription.request
 
-import models.matching.SafeId
+import models.matching.{OrgRegistrationInfo, SafeId}
 import models.{IdentifierType, UserAnswers}
 import pages._
 import play.api.libs.json.{Json, Reads, Writes}
@@ -45,7 +45,12 @@ object CreateSubscriptionRequest extends UserAnswersHelper {
           CreateSubscriptionRequest(
             idType = IdentifierType.SAFE,
             idNumber = safeId.value,
-            tradingName = userAnswers.get(BusinessTradingNameWithoutIDPage),
+            tradingName = (userAnswers.get(BusinessNamePage), userAnswers.get(BusinessTradingNameWithoutIDPage), userAnswers.get(RegistrationInfoPage)) match {
+              case (Some(businessName), _, _)             => Some(businessName)
+              case (_, Some(tradingName), _)              => Some(tradingName)
+              case (_, _, Some(org: OrgRegistrationInfo)) => Some(org.name)
+              case _                                      => None
+            },
             gbUser = isGBUser(userAnswers),
             primaryContact = primaryContact,
             secondaryContact = value

--- a/test/models/subscription/CreateSubscriptionRequestSpec.scala
+++ b/test/models/subscription/CreateSubscriptionRequestSpec.scala
@@ -55,7 +55,43 @@ class CreateSubscriptionRequestSpec extends SpecBase with ScalaCheckPropertyChec
           CreateSubscriptionRequest(
             idType = IdentifierType.SAFE,
             idNumber = safeId.value,
-            tradingName = None,
+            tradingName = Some(businessName),
+            gbUser = true,
+            primaryContact = ContactInformation(
+              contactInformation = OrganisationDetails(
+                name = contactName
+              ),
+              email = TestEmail,
+              phone = Some(TestPhoneNumber)
+            ),
+            secondaryContact = None
+          )
+        )
+
+      }
+
+      "for a business with id (org affinity group) registrationInfo" in {
+        val contactName      = nameGen.sample.value
+        val registrationInfo = arbitraryOrgRegistrationInfo.arbitrary.sample.value
+
+        val userAnswers = UserAnswers("")
+          .set(ReporterTypePage, ReporterType.LimitedCompany).success.value
+          .set(RegisteredAddressInUKPage, true).success.value
+          .set(WhatIsYourUTRPage, UniqueTaxpayerReference(validUtr.sample.value)).success.value
+          .set(ContactNamePage, contactName).success.value
+          .set(ContactEmailPage, TestEmail).success.value
+          .set(ContactHavePhonePage, true).success.value
+          .set(ContactPhonePage, TestPhoneNumber).success.value
+          .set(HaveSecondContactPage, false).success.value
+          .set(RegistrationInfoPage, registrationInfo).success.value
+
+        val result = CreateSubscriptionRequest.buildSubscriptionRequest(safeId, userAnswers, AffinityGroup.Organisation)
+
+        result mustBe Some(
+          CreateSubscriptionRequest(
+            idType = IdentifierType.SAFE,
+            idNumber = safeId.value,
+            tradingName = Some(registrationInfo.name),
             gbUser = true,
             primaryContact = ContactInformation(
               contactInformation = OrganisationDetails(
@@ -142,7 +178,7 @@ class CreateSubscriptionRequestSpec extends SpecBase with ScalaCheckPropertyChec
           CreateSubscriptionRequest(
             idType = IdentifierType.SAFE,
             idNumber = safeId.value,
-            tradingName = None,
+            tradingName = Some(businessName),
             gbUser = true,
             primaryContact = ContactInformation(
               contactInformation = OrganisationDetails(


### PR DESCRIPTION
Updated `CreateSubscriptionRequest` to derive the trading name based on user answers prioritizing business name, trading name, or organization registration info. Adjusted test cases to include scenarios for all possible trading name sources to ensure coverage.